### PR TITLE
[fix] TypeORM Entity 수정, [feat] post 요청 api 구현

### DIFF
--- a/BackEnd/funbox/src/users/dto/near-users.dto.ts
+++ b/BackEnd/funbox/src/users/dto/near-users.dto.ts
@@ -1,0 +1,7 @@
+export class NearUsersDto {
+    id: number;
+    username: string;
+    locX: number;
+    locY: number;
+    isMsgInAnHour: boolean;
+}

--- a/BackEnd/funbox/src/users/user.entity.ts
+++ b/BackEnd/funbox/src/users/user.entity.ts
@@ -5,24 +5,24 @@ export class User extends BaseEntity {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column()
+    @Column({length: 15, nullable: true})
     username: string;
 
-    @Column()
-    created_at: string; //timestamp
+    @Column({type: 'timestamp',nullable: false})
+    created_at: string;
 
-    @Column()
+    @Column({length: 255, nullable: true})
     profile_url: string;
 
-    @Column()
+    @Column({type: 'double', nullable: true})
     locX: number;
 
-    @Column()
+    @Column({type: 'double', nullable: true})
     locY: number;
 
-    @Column()
+    @Column({length: 31, nullable: true})
     message: string;
 
-    @Column()
-    messaged_at: string; //timestamp
+    @Column({type: 'timestamp',nullable: true})
+    messaged_at: string;
 }

--- a/BackEnd/funbox/src/users/users.controller.ts
+++ b/BackEnd/funbox/src/users/users.controller.ts
@@ -1,6 +1,8 @@
 import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { User } from './user.entity';
+import { UserLocationDto } from './dto/user-location.dto';
+import { NearUsersDto } from './dto/near-users.dto';
 
 @Controller('users')
 export class UsersController {
@@ -14,5 +16,11 @@ export class UsersController {
     @Get('/create')
     createUser(): Promise<User> {
         return this.usersService.createUsertest();
+    }
+
+    @Post()
+    async updateUserLocationAndReturnNearUsers(@Body() userLocationDto: UserLocationDto): Promise<NearUsersDto[]> {
+        await this.usersService.updateUserLocation(userLocationDto);
+        return await this.usersService.findNearUsers(userLocationDto);
     }
 }

--- a/BackEnd/funbox/src/users/users.service.ts
+++ b/BackEnd/funbox/src/users/users.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { User } from './user.entity';
+import { UserLocationDto } from './dto/user-location.dto';
+import { NearUsersDto } from './dto/near-users.dto';
 
 @Injectable()
 export class UsersService {
@@ -13,5 +15,36 @@ export class UsersService {
         user.message =  "hihi";
         user.messaged_at = "123123";
         return await user.save();
+    }
+
+    async updateUserLocation(userLocationDto: UserLocationDto): Promise<User> {
+        const user = await User.findOne({where : {id:1}}) // [!]OAuth 구현 후, id:1 부분 변경 필요
+        user.locX = userLocationDto.locX;
+        user.locY = userLocationDto.locY;
+        await user.save();
+        return user;
+    }
+
+    async findNearUsers(userLocationDto: UserLocationDto) : Promise<NearUsersDto[]> {
+        const users = await findNearUsersAlgorithm() // [!] 주변 조회 알고리즘 고도화 필요
+        const nearUsersDto = [];
+        users.forEach(user => { 
+            nearUsersDto.push(transFromUserToDto(user));
+        });
+        return nearUsersDto;
+
+        function transFromUserToDto(user: User) { //[?] 구조분해할당으로 간지나게 하고싶음...
+            const dto = new NearUsersDto();
+            dto.id = user.id;
+            dto.username = user.username;
+            dto.locX = user.locX;
+            dto.locY = user.locY;
+            dto.isMsgInAnHour = true; // [!] timestamp 관련 로직 필요
+            return dto;
+        }
+
+        async function findNearUsersAlgorithm(): Promise<User[]> {
+            return await User.find()
+        }
     }
 }

--- a/test.js
+++ b/test.js
@@ -1,11 +1,12 @@
-fetch('http://localhost:3000/users/location', {
+fetch('http://localhost:3000/users', {
     method : "POST",
     headers: {
         'Content-Type':'application/json'
     },
-    body : JSON.stringify({locX:666.6666,locY:666.6666})
+    body : JSON.stringify({locX:777.666666666666666,locY:666.6666666666666666})
 }).then((res)=>{
     return res.json();
 }).then((data)=>{
     console.log(data);
 });
+


### PR DESCRIPTION
# 제목
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
issue62 -> dev_back

### 변경사항
[fix] TypeORM Entity 수정
DB설계의 의도에 맞게 TypeORM의 Entity의 설정을 개선하였다.

[feat] post 요청 api 구현
post /users의 api를 구현하였다.
body로 오는 {locX,locY}를 (현재는 user[1]에) 갱신하고,
그 주변의 유저(현재는 모든 유저)의 DTO를 반환한다.

### 테스트 결과
```
$ node test.js
[
  {
    id: 1,
    username: null,
    locX: 777.6666666666666,
    locY: 666.6666666666666,
    isMsgInAnHour: true
  },
  { id: 2, username: null, locX: 0, locY: 0, isMsgInAnHour: true }
]
```
잘 됨.
