### PR TITLE
[feat] 단일 유저 조회 API, 유저 메시지 수정 API

### DIFF
--- a/BackEnd/funbox/src/users/dto/user-response.dto.ts
+++ b/BackEnd/funbox/src/users/dto/user-response.dto.ts
@@ -1,0 +1,15 @@
+import { User } from "../user.entity";
+
+export class UserResponseDto {
+    name: string;
+    profileUrl: string;
+    message: string;
+
+    static of(user: User): UserResponseDto {
+        return {
+            name: user.username,
+            profileUrl: user.profile_url,
+            message: user.message,
+        };
+    }
+}

--- a/BackEnd/funbox/src/users/users.controller.ts
+++ b/BackEnd/funbox/src/users/users.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { User } from './user.entity';
+import { UserResponseDto } from './dto/user-response.dto';
 
 @Controller('users')
 export class UsersController {
@@ -14,5 +15,11 @@ export class UsersController {
     @Get('/create')
     createUser(): Promise<User> {
         return this.usersService.createUsertest();
+    }
+
+    @Get('/:id')
+    async getUserById(@Param('id') id: number): Promise<UserResponseDto> {
+        const user = await this.usersService.getUserById(id)
+        return UserResponseDto.of(user);
     }
 }

--- a/BackEnd/funbox/src/users/users.controller.ts
+++ b/BackEnd/funbox/src/users/users.controller.ts
@@ -22,4 +22,13 @@ export class UsersController {
         const user = await this.usersService.getUserById(id)
         return UserResponseDto.of(user);
     }
+
+    @Patch("/message")
+    async updateUserMessage(
+        @Body('message') message: string
+    ): Promise<UserResponseDto> {
+        const id = 1; // TODO: auth 모듈을 통해 user id 추출
+        const user = await this.usersService.updateUserMessage(id, message)
+        return UserResponseDto.of(user);
+    }
 }

--- a/BackEnd/funbox/src/users/users.service.ts
+++ b/BackEnd/funbox/src/users/users.service.ts
@@ -14,4 +14,12 @@ export class UsersService {
         user.messaged_at = "123123";
         return await user.save();
     }
+
+    async getUserById(id: number): Promise<User> {
+        const found = await User.findOneBy({id: id});
+        if (!found) {
+            throw new NotFoundException(`Can't find User with id ${id}`);
+        }
+        return found;
+    }
 }

--- a/BackEnd/funbox/src/users/users.service.ts
+++ b/BackEnd/funbox/src/users/users.service.ts
@@ -22,4 +22,10 @@ export class UsersService {
         }
         return found;
     }
+
+    async updateUserMessage(id: number, message: string): Promise<User> {
+        const user = await this.getUserById(id);
+        user.message = message;
+        return await user.save();
+    }
 }


### PR DESCRIPTION
# 제목
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
feature-singleUser -> dev_back

### 특이사항
#### 단일 유저 조회 API
- 유저 엔티티 객체로 정해진 형식의 응답을 만들기 위해 UserResponseDto를 사용했습니다.
    - 참고 문서 1: [NestJS에서 Response DTO를 만들 때 new는 넣어둬](https://velog.io/@yullivan/NestJS%EC%97%90%EC%84%9C-Response-DTO%EB%A5%BC-%EB%A7%8C%EB%93%A4-%EB%95%8C-new%EB%8A%94-%EB%84%A3%EC%96%B4%EB%91%AC)
    - 참고 문서 2: [Google JSON Style Guide](https://google.github.io/styleguide/jsoncstyleguide.xml#Property_Name_Guidelines)
#### 유저 메시지 수정 API
- auth 모듈이 아직 구현되지 않은 상태이기 때문에, 우선 id를 1로 할당하고 구현했습니다.
- 추후 auth 모듈이 구현되면, 해당 모듈을 통해 요청을 보낸 user의 id를 추출하도록 변경할 예정입니다.

### 테스트 결과

#### 단일 유저 조회 API
<img width="978" alt="스크린샷 2023-11-16 22 55 04" src="https://github.com/boostcampwm2023/and05-funbox/assets/42964952/073695f2-c437-4d54-9efd-18af4137c493">

#### 유저 메시지 수정 API
<img width="978" alt="스크린샷 2023-11-16 22 55 39" src="https://github.com/boostcampwm2023/and05-funbox/assets/42964952/5a89ddb9-722d-4ffe-8133-206f420df0e6">


