### PR TITLE
refactor: 코드 정리 및 게임 화면 구현을 위한 뼈대 구성

### DIFF
--- a/Android/FunBox/app/src/main/java/com/example/funbox/MessageDialog.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/MessageDialog.kt
@@ -28,7 +28,6 @@ class MessageDialog: DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.positiveButton.setOnClickListener{
-            viewModel.setMessage(binding.editTextText.text.toString())
             dismiss()
         }
     }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/gameselect/GameSelectFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/gameselect/GameSelectFragment.kt
@@ -1,0 +1,26 @@
+package com.example.funbox.presentation.game.gameselect
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import com.example.funbox.R
+import com.example.funbox.databinding.FragmentGameSelectBinding
+import com.example.funbox.presentation.BaseFragment
+
+class GameSelectFragment : BaseFragment<FragmentGameSelectBinding>(R.layout.fragment_game_select) {
+
+    private val viewModel: GameSelectViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+
+        collectLatestFlow(viewModel.gameSelectUiEvent) { handleUiEvent(it) }
+    }
+
+    private fun handleUiEvent(event: GameSelectUiEvent) = when (event) {
+        is GameSelectUiEvent.NetworkErrorEvent -> {
+            showSnackBar(R.string.network_error_message)
+        }
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/gameselect/GameSelectUiEvent.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/gameselect/GameSelectUiEvent.kt
@@ -1,0 +1,6 @@
+package com.example.funbox.presentation.game.gameselect
+
+sealed class GameSelectUiEvent {
+
+    data class NetworkErrorEvent(val message: String = "Network Error") : GameSelectUiEvent()
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/gameselect/GameSelectUiState.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/gameselect/GameSelectUiState.kt
@@ -1,0 +1,5 @@
+package com.example.funbox.presentation.game.gameselect
+
+data class GameSelectUiState(
+    val tmp: Boolean = true
+)

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/gameselect/GameSelectViewModel.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/gameselect/GameSelectViewModel.kt
@@ -1,0 +1,18 @@
+package com.example.funbox.presentation.game.gameselect
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class GameSelectViewModel : ViewModel() {
+
+    private val _gameSelectUiEvent = MutableSharedFlow<GameSelectUiEvent>()
+    val gameSelectUiEvent = _gameSelectUiEvent.asSharedFlow()
+
+    private val _gameSelectUiState = MutableStateFlow<GameSelectUiState>(GameSelectUiState())
+    val gameSelectUiState = _gameSelectUiState.asStateFlow()
+
+
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizFragment.kt
@@ -1,0 +1,81 @@
+package com.example.funbox.presentation.game.quiz
+
+import android.os.Bundle
+import android.view.View
+import androidx.annotation.UiThread
+import androidx.fragment.app.viewModels
+import com.example.funbox.R
+import com.example.funbox.databinding.FragmentQuizBinding
+import com.example.funbox.presentation.BaseFragment
+import com.naver.maps.map.MapFragment
+import com.naver.maps.map.MapView
+import com.naver.maps.map.NaverMap
+import com.naver.maps.map.OnMapReadyCallback
+
+class QuizFragment : BaseFragment<FragmentQuizBinding>(R.layout.fragment_quiz), OnMapReadyCallback {
+
+    private val viewModel: QuizViewModel by viewModels()
+    private lateinit var mapView: MapView
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+        mapView = binding.mapViewGame
+        mapView.onCreate(savedInstanceState)
+
+        val cfm = childFragmentManager
+        val mapFragment = cfm.findFragmentById(R.id.map_view_game) as MapFragment?
+            ?: MapFragment.newInstance().also { mapFragment ->
+                cfm.beginTransaction().add(R.id.map_view_game, mapFragment).commit()
+            }
+        mapFragment.getMapAsync(this)
+
+        collectLatestFlow(viewModel.quizUiEvent) { handleUiEvent(it) }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mapView.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mapView.onPause()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView.onSaveInstanceState(outState)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView.onStop()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        mapView.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView.onLowMemory()
+    }
+
+    @UiThread
+    override fun onMapReady(p0: NaverMap) {
+
+    }
+
+    private fun handleUiEvent(event: QuizUiEvent) = when (event) {
+        is QuizUiEvent.NetworkErrorEvent -> {
+            showSnackBar(R.string.network_error_message)
+        }
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizUiEvent.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizUiEvent.kt
@@ -1,0 +1,6 @@
+package com.example.funbox.presentation.game.quiz
+
+sealed class QuizUiEvent {
+
+    data class NetworkErrorEvent(val message: String = "Network Error") : QuizUiEvent()
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizUiState.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizUiState.kt
@@ -1,0 +1,5 @@
+package com.example.funbox.presentation.game.quiz
+
+data class QuizUiState(
+    val tmp: Boolean = true
+)

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizViewModel.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizViewModel.kt
@@ -1,0 +1,18 @@
+package com.example.funbox.presentation.game.quiz
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class QuizViewModel : ViewModel() {
+
+    private val _quizUiEvent = MutableSharedFlow<QuizUiEvent>()
+    val quizUiEvent = _quizUiEvent.asSharedFlow()
+
+    private val _quizUiState = MutableStateFlow<QuizUiState>(QuizUiState())
+    val quizUiState = _quizUiState.asStateFlow()
+
+
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitFragment.kt
@@ -1,0 +1,26 @@
+package com.example.funbox.presentation.game.wait
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import com.example.funbox.R
+import com.example.funbox.databinding.FragmentWaitBinding
+import com.example.funbox.presentation.BaseFragment
+
+class WaitFragment : BaseFragment<FragmentWaitBinding>(R.layout.fragment_wait) {
+
+    private val viewModel: WaitViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+
+        collectLatestFlow(viewModel.waitUiEvent) { handleUiEvent(it) }
+    }
+
+    private fun handleUiEvent(event: WaitUiEvent) = when (event) {
+        is WaitUiEvent.NetworkErrorEvent -> {
+            showSnackBar(R.string.network_error_message)
+        }
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiEvent.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiEvent.kt
@@ -1,0 +1,6 @@
+package com.example.funbox.presentation.game.wait
+
+sealed class WaitUiEvent {
+
+    data class NetworkErrorEvent(val message: String = "Network Error") : WaitUiEvent()
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiState.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiState.kt
@@ -1,0 +1,5 @@
+package com.example.funbox.presentation.game.wait
+
+data class WaitUiState(
+    val tmp: Boolean = true
+)

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitViewModel.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitViewModel.kt
@@ -1,0 +1,18 @@
+package com.example.funbox.presentation.game.wait
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class WaitViewModel : ViewModel() {
+
+    private val _waitUiEvent = MutableSharedFlow<WaitUiEvent>()
+    val waitUiEvent = _waitUiEvent.asSharedFlow()
+
+    private val _waitUiState = MutableStateFlow<WaitUiState>(WaitUiState())
+    val waitUiState = _waitUiState.asStateFlow()
+
+
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/login/AccessPermission.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/login/AccessPermission.kt
@@ -8,4 +8,8 @@ object AccessPermission {
         Manifest.permission.WRITE_EXTERNAL_STORAGE,
         Manifest.permission.READ_EXTERNAL_STORAGE
     )
+
+    val locationPermissionList = arrayOf(
+        Manifest.permission.ACCESS_FINE_LOCATION
+    )
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/login/SplashActivity.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/login/SplashActivity.kt
@@ -13,7 +13,7 @@ class SplashActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         Timber.plant(Timber.DebugTree())
-        startActivity(Intent(this, TitleActivity::class.java))
+        startActivity(Intent(this, MainActivity::class.java))
         finish()
     }
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/map/MapBindingAdapters.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/map/MapBindingAdapters.kt
@@ -1,0 +1,4 @@
+package com.example.funbox.presentation.map
+
+class MapBindingAdapters {
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/map/MapFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/map/MapFragment.kt
@@ -9,7 +9,6 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Bundle
 import android.os.Handler
-import android.util.Log
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -24,11 +23,8 @@ import com.naver.maps.map.overlay.Marker
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.activityViewModels
-import com.example.funbox.data.network.service.LoadUserService
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
-
-
 
 class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnMapReadyCallback {
 
@@ -40,25 +36,27 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
     private lateinit var fusedLocationClient: FusedLocationProviderClient
     private val handler = Handler()
 
+    private fun handleUiEvent(event: MapUiEvent) = when (event) {
+        is MapUiEvent.MessageOpen -> {
+            MessageDialog().show(parentFragmentManager, "messageDialog")
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.mapViewModel = viewModel
+        binding.vm = viewModel
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(requireActivity())
         setLocationListener()
+
+        collectLatestFlow(viewModel.mapUiEvent) { handleUiEvent(it) }
 
         binding.floatingActionButton.setOnClickListener {
             toggleFab()
         }
 
-        binding.floatingWrite.setOnClickListener {
-            val messageDialog = MessageDialog()
-            messageDialog.show(parentFragmentManager, "messageDialog")
-        }
-
         viewModel.mapApi()
         initMapView()
     }
-
 
     private fun initMapView() {
         val fm = childFragmentManager
@@ -112,7 +110,7 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
                 location?.let {
                     val latitude = it.latitude
                     val longitude = it.longitude
-                    viewModel.setXY(latitude,longitude)
+                    viewModel.setXY(latitude, longitude)
 
                     sendXYtoApi(latitude, longitude)
 
@@ -120,11 +118,9 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
             }
     }
 
-
     private fun sendXYtoApi(latitude: Double, longitude: Double) {
         //LoadUserService.create().search(latitude,longitude).execute()
     }
-
 
     private fun toggleFab() {
         if (isFabOpen) {
@@ -192,5 +188,4 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
             }
         }
     }
-
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/map/MapUiEvent.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/map/MapUiEvent.kt
@@ -1,0 +1,6 @@
+package com.example.funbox.presentation.map
+
+sealed class MapUiEvent {
+    // data class NetworkErrorEvent(val message: String = "Network Error") : MapUiEvent()
+    data object MessageOpen : MapUiEvent()
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/map/MapViewModel.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/map/MapViewModel.kt
@@ -1,12 +1,17 @@
 package com.example.funbox.presentation.map
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.funbox.data.dto.User
 import com.example.funbox.data.dto.UserDetail
+import com.example.funbox.presentation.login.nickname.NicknameUiEvent
 import com.naver.maps.geometry.LatLng
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 class MapViewModel : ViewModel() {
     private val _myMessage = MutableStateFlow("")
@@ -20,9 +25,12 @@ class MapViewModel : ViewModel() {
     private val _userDetail= MutableStateFlow(UserDetail("","",""))
     val userDetail : StateFlow<UserDetail> = _userDetail
 
-    fun setMessage(message: String) {
-        _myMessage.update {
-            message
+    private val _mapUiEvent = MutableSharedFlow<MapUiEvent>()
+    val mapUiEvent = _mapUiEvent.asSharedFlow()
+
+    fun startMessageDialog() {
+        viewModelScope.launch {
+            _mapUiEvent.emit(MapUiEvent.MessageOpen)
         }
     }
 

--- a/Android/FunBox/app/src/main/res/layout/dialog_message.xml
+++ b/Android/FunBox/app/src/main/res/layout/dialog_message.xml
@@ -5,6 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="300dp"
         android:layout_height="200dp"

--- a/Android/FunBox/app/src/main/res/layout/fragment_game_select.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_game_select.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.example.funbox.presentation.game.gameselect.GameSelectViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/background_color"
+        tools:context=".presentation.game.gameselect.GameSelectFragment">
+
+        <ImageButton
+            android:id="@+id/btn_back_game_select"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/baseline_arrow_back_24"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:contentDescription="@string/btn_back_game_select_description" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/Android/FunBox/app/src/main/res/layout/fragment_map.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_map.xml
@@ -4,7 +4,7 @@
 
     <data>
         <variable
-            name="mapViewModel"
+            name="vm"
             type="com.example.funbox.presentation.map.MapViewModel" />
     </data>
 
@@ -13,6 +13,7 @@
         android:layout_height="match_parent">
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:onClick="@{() -> vm.startMessageDialog()}"
             android:id="@+id/floating_write"
             style="?attr/floatingActionButtonSmallStyle"
             android:layout_width="wrap_content"
@@ -53,13 +54,6 @@
             android:layout_height="match_parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@{mapViewModel.myMessage}"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/Android/FunBox/app/src/main/res/layout/fragment_quiz.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_quiz.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="vm"
+            type="com.example.funbox.presentation.game.quiz.QuizViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.game.quiz.QuizFragment">
+
+        <com.naver.maps.map.MapView
+            android:id="@+id/map_view_game"
+            android:name="com.naver.maps.map.MapFragment"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/Android/FunBox/app/src/main/res/layout/fragment_wait.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_wait.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="vm"
+            type="com.example.funbox.presentation.game.wait.WaitViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.game.wait.WaitFragment">
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/Android/FunBox/app/src/main/res/navigation/main_navi_graph.xml
+++ b/Android/FunBox/app/src/main/res/navigation/main_navi_graph.xml
@@ -1,11 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nvai_graph"
-    app:startDestination="@id/mapFragment">
+    app:startDestination="@id/GameSelectFragment">
 
     <fragment
         android:id="@+id/mapFragment"
         android:name="com.example.funbox.presentation.map.MapFragment"
-        android:label="MapFragment" />
+        android:label="MapFragment">
+        <action
+            android:id="@+id/action_MapFragment_to_GameSelectFragment"
+            app:destination="@id/GameSelectFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/GameSelectFragment"
+        android:name="com.example.funbox.presentation.game.gameselect.GameSelectFragment"
+        tools:layout="GameSelectFragment">
+        <action
+            android:id="@+id/action_GameSelectFragment_to_MapFragment"
+            app:destination="@id/mapFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/WaitFragment"
+        android:name="com.example.funbox.presentation.game.wait.WaitFragment"
+        tools:layout="WaitFragment">
+    </fragment>
+
+    <fragment
+        android:id="@+id/QuizFragment"
+        android:name="com.example.funbox.presentation.game.quiz.QuizFragment"
+        tools:layout="QuizFragment">
+    </fragment>
 </navigation>

--- a/Android/FunBox/app/src/main/res/values/strings.xml
+++ b/Android/FunBox/app/src/main/res/values/strings.xml
@@ -8,9 +8,6 @@
     <string name="nickname_setting_title">닉네임을 설정해주세요</string>
     <string name="profile_setting_title">프로필을 설정해주세요</string>
     <string name="description">매뉴</string>
-    <string name="iv_main_logo_description">FunBox 로고</string>
-    <string name="btn_main_naver_login_description">NAVER 소셜 로그인 버튼</string>
-    <string name="btn_add_profile_description">프로필 추가 버튼</string>
     <string name="fragment_title_label">타이틀 화면</string>
     <string name="fragment_nickname_label">닉네임 입력</string>
     <string name="fragment_profile_label">프로필 설정</string>
@@ -18,4 +15,9 @@
     <string name="permission_message_toast">권한 허용이 필요합니다.</string>
     <string name="social_login_info_naver_client_name">네이버 아이디 로그인</string>
     <string name="social_login_info_naver_success">NAVER 로그인 성공</string>
+
+    <string name="iv_main_logo_description">FunBox 로고</string>
+    <string name="btn_main_naver_login_description">NAVER 소셜 로그인 버튼</string>
+    <string name="btn_add_profile_description">프로필 추가 버튼</string>
+    <string name="btn_back_game_select_description">게임 선택 화면의 백 버튼</string>
 </resources>


### PR DESCRIPTION
# 제목
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
ex) feat-gameUI -> dev_and

### 변경사항
 - 코드를 정리하고 게임 화면 구현을 위해 게임 선택, 대기, 퀴즈 화면 총 3개의 Fragment를 만들었고 각각에 해당하는 ViewModel, UiEvent, UiState를 만들었습니다.