### PR TITLE
[feat] 매칭 대기 화면 UI 추가

### DIFF
--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitBindingAdapters.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitBindingAdapters.kt
@@ -1,0 +1,11 @@
+package com.example.funbox.presentation.game.wait
+
+import android.widget.ImageView
+import androidx.databinding.BindingAdapter
+import coil.load
+import com.example.funbox.R
+
+@BindingAdapter("app:setImage")
+fun ImageView.bindImage(waitUiState: WaitUiState) {
+    load(R.drawable.profile_game)
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitFragment.kt
@@ -3,6 +3,7 @@ package com.example.funbox.presentation.game.wait
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.example.funbox.R
 import com.example.funbox.databinding.FragmentWaitBinding
 import com.example.funbox.presentation.BaseFragment
@@ -21,6 +22,10 @@ class WaitFragment : BaseFragment<FragmentWaitBinding>(R.layout.fragment_wait) {
     private fun handleUiEvent(event: WaitUiEvent) = when (event) {
         is WaitUiEvent.NetworkErrorEvent -> {
             showSnackBar(R.string.network_error_message)
+        }
+
+        is WaitUiEvent.WaitSuccess -> {
+            findNavController().navigate(R.id.action_WaitFragment_to_QuizFragment)
         }
     }
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiEvent.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiEvent.kt
@@ -3,4 +3,5 @@ package com.example.funbox.presentation.game.wait
 sealed class WaitUiEvent {
 
     data class NetworkErrorEvent(val message: String = "Network Error") : WaitUiEvent()
+    data object WaitSuccess : WaitUiEvent()
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiState.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiState.kt
@@ -1,5 +1,6 @@
 package com.example.funbox.presentation.game.wait
 
 data class WaitUiState(
-    val tmp: Boolean = true
+    val waiting: Boolean = true,
+    val finishWaiting: Boolean = false
 )

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitViewModel.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitViewModel.kt
@@ -13,6 +13,4 @@ class WaitViewModel : ViewModel() {
 
     private val _waitUiState = MutableStateFlow<WaitUiState>(WaitUiState())
     val waitUiState = _waitUiState.asStateFlow()
-
-
 }

--- a/Android/FunBox/app/src/main/res/drawable/profile_game.xml
+++ b/Android/FunBox/app/src/main/res/drawable/profile_game.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="98dp"
+    android:height="105dp"
+    android:viewportWidth="98"
+    android:viewportHeight="105">
+  <path
+      android:pathData="M50.31,43.87C54.81,43.87 58.46,39.86 58.46,34.91C58.46,29.97 54.81,25.96 50.31,25.96C45.82,25.96 42.17,29.97 42.17,34.91C42.17,39.86 45.82,43.87 50.31,43.87ZM50.31,52.83C59.31,52.83 66.6,44.81 66.6,34.91C66.6,25.02 59.31,17 50.31,17C41.32,17 34.03,25.02 34.03,34.91C34.03,44.81 41.32,52.83 50.31,52.83Z"
+      android:fillColor="#5D5D79"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M49.5,58.41C38.26,58.41 29.14,68.31 29.14,80.51H21C21,63.42 33.76,49.57 49.5,49.57C65.24,49.57 78,63.42 78,80.51H69.86C69.86,68.31 60.74,58.41 49.5,58.41Z"
+      android:fillColor="#5D5D79"
+      android:fillType="evenOdd"/>
+</vector>

--- a/Android/FunBox/app/src/main/res/drawable/rounded_corner_rect_shadow.xml
+++ b/Android/FunBox/app/src/main/res/drawable/rounded_corner_rect_shadow.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <size
+        android:width="98dp"
+        android:height="105dp" />
+    <solid android:color="@color/background_color" />
+    <corners android:radius="20dp"/>
+</shape>

--- a/Android/FunBox/app/src/main/res/drawable/wait_background.xml
+++ b/Android/FunBox/app/src/main/res/drawable/wait_background.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="315dp"
+    android:height="251dp"
+    android:viewportWidth="315"
+    android:viewportHeight="251">
+  <path
+      android:pathData="M35,0L280,0A35,35 0,0 1,315 35L315,216A35,35 0,0 1,280 251L35,251A35,35 0,0 1,0 216L0,35A35,35 0,0 1,35 0z"
+      android:fillColor="#E8DFCA"/>
+</vector>

--- a/Android/FunBox/app/src/main/res/layout/fragment_wait.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_wait.xml
@@ -1,18 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="vm"
             type="com.example.funbox.presentation.game.wait.WaitViewModel" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/background_color"
         tools:context=".presentation.game.wait.WaitFragment">
 
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/user_info_wait"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="72dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="32dp"
+            android:background="@drawable/wait_background"
+            android:contentDescription="@string/user_wait_description"
+            app:cardBackgroundColor="@color/edittext_color"
+            app:cardCornerRadius="40dp"
+            app:cardElevation="10dp"
+            app:layout_constraintBottom_toTopOf="@id/side_info_wait"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/user_profile_wait"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top|center"
+                android:layout_margin="16dp"
+                android:background="@drawable/rounded_corner_rect_shadow"
+                android:contentDescription="@string/user_profile_wait_description"
+                android:elevation="10dp"
+                app:setImage="@{vm.waitUiState}" />
+
+            <TextView
+                android:id="@+id/user_id_wait"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/user_id_wait"
+                android:textSize="40sp" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/side_info_wait"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="72dp"
+            android:background="@drawable/wait_background"
+            android:contentDescription="@string/side_wait_description"
+            app:cardBackgroundColor="@color/edittext_color"
+            app:cardCornerRadius="40dp"
+            app:cardElevation="10dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/user_info_wait">
+
+            <ImageView
+                android:id="@+id/side_profile_wait"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top|center"
+                android:layout_margin="16dp"
+                android:background="@drawable/rounded_corner_rect_shadow"
+                android:contentDescription="@string/side_profile_wait_description"
+                android:elevation="10dp"
+                app:setImage="@{vm.waitUiState}" />
+
+            <TextView
+                android:id="@+id/side_id_wait"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/side_id_wait"
+                android:textSize="40sp" />
+
+            <TextView
+                android:id="@+id/msg_wait"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|center"
+                android:layout_margin="16dp"
+                android:text="@string/msg_wait"
+                android:textSize="32sp" />
+
+        </com.google.android.material.card.MaterialCardView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Android/FunBox/app/src/main/res/navigation/main_navi_graph.xml
+++ b/Android/FunBox/app/src/main/res/navigation/main_navi_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nvai_graph"
-    app:startDestination="@id/settingFragment">
+    app:startDestination="@id/WaitFragment">
 
     <fragment
         android:id="@+id/mapFragment"

--- a/Android/FunBox/app/src/main/res/values/strings.xml
+++ b/Android/FunBox/app/src/main/res/values/strings.xml
@@ -17,9 +17,17 @@
     <string name="social_login_info_naver_success">NAVER 로그인 성공</string>
     <string name="game_question_card_title">질문 카드</string>
     <string name="game_to_be_determined">To Be Continued…</string>
+    <string name="user_id_wait">유저 아이디</string>
+    <string name="side_id_wait">상대 유저 아이디</string>
+    <string name="msg_wait">대기중…</string>
+    <string name="finish_wait">게임 시작</string>
 
     <string name="iv_main_logo_description">FunBox 로고</string>
     <string name="btn_main_naver_login_description">NAVER 소셜 로그인 버튼</string>
     <string name="btn_add_profile_description">프로필 추가 버튼</string>
     <string name="btn_back_game_select_description">게임 선택 화면의 백 버튼</string>
+    <string name="user_wait_description">유저 대기 UI</string>
+    <string name="side_wait_description">상대 유저 대기 UI</string>
+    <string name="user_profile_wait_description">유저 프로필 사진</string>
+    <string name="side_profile_wait_description">상대 유저 프로필 사진</string>
 </resources>


### PR DESCRIPTION
# 제목
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
ex) feat-waitUI -> dev_and

### 변경사항
 - 대기 화면 UI를 추가하였습니다.
   - 먼저 유저 정보에 대한 View들을 MaterialCardView로 감싸고, 프로필 사진과 아이디 View로 구성하였습니다.
   - 게임 수락 대기 상태인지를 나타내기 위해 상대 유저 아이디 View 밑에 새로운 TextView를 추가하여 대기중인지를 나타내도록 하였습니다.
   - elevation을 추가하여 프로필 사진에 그림자 효과를 나타내었습니다.
 
<p align="center">
   <img width=200, src="https://user-images.githubusercontent.com/55424662/284464861-e6e1e727-9d0b-4e11-b657-89c82ef5073c.png">
</p>

Close: #79