### PR TITLE
[feat] 퀴즈 게임 화면 UI 추가

### DIFF
--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/MainActivity.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/MainActivity.kt
@@ -1,7 +1,12 @@
 package com.example.funbox.presentation
 
+import android.graphics.Rect
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.MotionEvent
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
 import com.example.funbox.R
 import com.example.funbox.databinding.ActivityMainBinding
 
@@ -11,5 +16,38 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         binding = ActivityMainBinding.inflate(layoutInflater)
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
+        if (event?.action != MotionEvent.ACTION_DOWN) {
+            return super.dispatchTouchEvent(event)
+        }
+
+
+        if (this.currentFocus is EditText) {
+            val outRect = Rect()
+            this.currentFocus?.let {
+                it.getGlobalVisibleRect(outRect)
+                hideKeyboard(outRect, event, it)
+            }
+        }
+        return super.dispatchTouchEvent(event)
+    }
+
+    private fun hideKeyboard(
+        outRect: Rect,
+        event: MotionEvent,
+        it: View
+    ) {
+        if (!outRect.contains(event.rawX.toInt(), event.rawY.toInt())) {
+            it.clearFocus()
+
+            val inputMethodManager: InputMethodManager =
+                this.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+            inputMethodManager.hideSoftInputFromWindow(
+                it.windowToken,
+                InputMethodManager.HIDE_NOT_ALWAYS
+            )
+        }
     }
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizBindingAdapters.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizBindingAdapters.kt
@@ -1,0 +1,3 @@
+package com.example.funbox.presentation.game.quiz
+
+import androidx.databinding.BindingAdapter

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizFragment.kt
@@ -22,13 +22,7 @@ class QuizFragment : BaseFragment<FragmentQuizBinding>(R.layout.fragment_quiz), 
         binding.vm = viewModel
         mapView = binding.mapViewGame
         mapView.onCreate(savedInstanceState)
-
-        val cfm = childFragmentManager
-        val mapFragment = cfm.findFragmentById(R.id.map_view_game) as MapFragment?
-            ?: MapFragment.newInstance().also { mapFragment ->
-                cfm.beginTransaction().add(R.id.map_view_game, mapFragment).commit()
-            }
-        mapFragment.getMapAsync(this)
+        setNaverMap()
 
         collectLatestFlow(viewModel.quizUiEvent) { handleUiEvent(it) }
     }
@@ -73,9 +67,22 @@ class QuizFragment : BaseFragment<FragmentQuizBinding>(R.layout.fragment_quiz), 
 
     }
 
+    private fun setNaverMap() {
+        val cfm = childFragmentManager
+        val mapFragment = cfm.findFragmentById(R.id.map_view_game) as MapFragment?
+            ?: MapFragment.newInstance().also { mapFragment ->
+                cfm.beginTransaction().add(R.id.map_view_game, mapFragment).commit()
+            }
+        mapFragment.getMapAsync(this)
+    }
+
     private fun handleUiEvent(event: QuizUiEvent) = when (event) {
         is QuizUiEvent.NetworkErrorEvent -> {
             showSnackBar(R.string.network_error_message)
+        }
+
+        is QuizUiEvent.QuizAnswerSubmit -> {
+
         }
     }
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizUiEvent.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizUiEvent.kt
@@ -3,4 +3,5 @@ package com.example.funbox.presentation.game.quiz
 sealed class QuizUiEvent {
 
     data class NetworkErrorEvent(val message: String = "Network Error") : QuizUiEvent()
+    data object QuizAnswerSubmit : QuizUiEvent()
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizUiState.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizUiState.kt
@@ -1,5 +1,7 @@
 package com.example.funbox.presentation.game.quiz
 
 data class QuizUiState(
-    val tmp: Boolean = true
-)
+    val answerValidState: Boolean = false
+) {
+    val isAnswerSubmitBtnEnable: Boolean = (answerValidState)
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizViewModel.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/quiz/QuizViewModel.kt
@@ -5,8 +5,12 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import timber.log.Timber
 
 class QuizViewModel : ViewModel() {
+
+    private val latestAnswer = MutableStateFlow<String>("")
 
     private val _quizUiEvent = MutableSharedFlow<QuizUiEvent>()
     val quizUiEvent = _quizUiEvent.asSharedFlow()
@@ -14,5 +18,20 @@ class QuizViewModel : ViewModel() {
     private val _quizUiState = MutableStateFlow<QuizUiState>(QuizUiState())
     val quizUiState = _quizUiState.asStateFlow()
 
+    fun validateAnswer(answer: CharSequence) {
+        if (answer.isBlank()) {
+            _quizUiState.update { uiState ->
+                uiState.copy(answerValidState = false)
+            }
+        } else {
+            _quizUiState.update { uiState ->
+                uiState.copy(answerValidState = true)
+            }
+        }
+        latestAnswer.value = answer.toString()
+    }
 
+    fun submitAnswer() {
+        Timber.d("Answer: ${latestAnswer.value}")
+    }
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitBindingAdapters.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitBindingAdapters.kt
@@ -1,0 +1,11 @@
+package com.example.funbox.presentation.game.wait
+
+import android.widget.ImageView
+import androidx.databinding.BindingAdapter
+import coil.load
+import com.example.funbox.R
+
+@BindingAdapter("app:setImage")
+fun ImageView.bindImage(waitUiState: WaitUiState) {
+    load(R.drawable.profile_game)
+}

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitFragment.kt
@@ -3,6 +3,7 @@ package com.example.funbox.presentation.game.wait
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.example.funbox.R
 import com.example.funbox.databinding.FragmentWaitBinding
 import com.example.funbox.presentation.BaseFragment
@@ -21,6 +22,10 @@ class WaitFragment : BaseFragment<FragmentWaitBinding>(R.layout.fragment_wait) {
     private fun handleUiEvent(event: WaitUiEvent) = when (event) {
         is WaitUiEvent.NetworkErrorEvent -> {
             showSnackBar(R.string.network_error_message)
+        }
+
+        is WaitUiEvent.WaitSuccess -> {
+            findNavController().navigate(R.id.action_WaitFragment_to_QuizFragment)
         }
     }
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiEvent.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiEvent.kt
@@ -3,4 +3,5 @@ package com.example.funbox.presentation.game.wait
 sealed class WaitUiEvent {
 
     data class NetworkErrorEvent(val message: String = "Network Error") : WaitUiEvent()
+    data object WaitSuccess : WaitUiEvent()
 }

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiState.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitUiState.kt
@@ -1,5 +1,6 @@
 package com.example.funbox.presentation.game.wait
 
 data class WaitUiState(
-    val tmp: Boolean = true
+    val waiting: Boolean = true,
+    val finishWaiting: Boolean = false
 )

--- a/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitViewModel.kt
+++ b/Android/FunBox/app/src/main/java/com/example/funbox/presentation/game/wait/WaitViewModel.kt
@@ -13,6 +13,4 @@ class WaitViewModel : ViewModel() {
 
     private val _waitUiState = MutableStateFlow<WaitUiState>(WaitUiState())
     val waitUiState = _waitUiState.asStateFlow()
-
-
 }

--- a/Android/FunBox/app/src/main/res/drawable/answer_edittext.xml
+++ b/Android/FunBox/app/src/main/res/drawable/answer_edittext.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="295dp"
+    android:height="81dp"
+    android:viewportWidth="295"
+    android:viewportHeight="81">
+  <path
+      android:pathData="M14,0L281,0A10,10 0,0 1,291 10L291,63A10,10 0,0 1,281 73L14,73A10,10 0,0 1,4 63L4,10A10,10 0,0 1,14 0z"
+      android:fillColor="@color/background_color"/>
+</vector>

--- a/Android/FunBox/app/src/main/res/drawable/profile_game.xml
+++ b/Android/FunBox/app/src/main/res/drawable/profile_game.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="98dp"
+    android:height="105dp"
+    android:viewportWidth="98"
+    android:viewportHeight="105">
+  <path
+      android:pathData="M50.31,43.87C54.81,43.87 58.46,39.86 58.46,34.91C58.46,29.97 54.81,25.96 50.31,25.96C45.82,25.96 42.17,29.97 42.17,34.91C42.17,39.86 45.82,43.87 50.31,43.87ZM50.31,52.83C59.31,52.83 66.6,44.81 66.6,34.91C66.6,25.02 59.31,17 50.31,17C41.32,17 34.03,25.02 34.03,34.91C34.03,44.81 41.32,52.83 50.31,52.83Z"
+      android:fillColor="#5D5D79"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M49.5,58.41C38.26,58.41 29.14,68.31 29.14,80.51H21C21,63.42 33.76,49.57 49.5,49.57C65.24,49.57 78,63.42 78,80.51H69.86C69.86,68.31 60.74,58.41 49.5,58.41Z"
+      android:fillColor="#5D5D79"
+      android:fillType="evenOdd"/>
+</vector>

--- a/Android/FunBox/app/src/main/res/drawable/rounded_corner_rect_shadow.xml
+++ b/Android/FunBox/app/src/main/res/drawable/rounded_corner_rect_shadow.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <size
+        android:width="98dp"
+        android:height="105dp" />
+    <solid android:color="@color/background_color" />
+    <corners android:radius="20dp"/>
+</shape>

--- a/Android/FunBox/app/src/main/res/drawable/wait_background.xml
+++ b/Android/FunBox/app/src/main/res/drawable/wait_background.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="315dp"
+    android:height="251dp"
+    android:viewportWidth="315"
+    android:viewportHeight="251">
+  <path
+      android:pathData="M35,0L280,0A35,35 0,0 1,315 35L315,216A35,35 0,0 1,280 251L35,251A35,35 0,0 1,0 216L0,35A35,35 0,0 1,35 0z"
+      android:fillColor="#E8DFCA"/>
+</vector>

--- a/Android/FunBox/app/src/main/res/layout/fragment_nickname.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_nickname.xml
@@ -34,10 +34,10 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <EditText
-                android:layout_marginTop="32dp"
                 android:id="@+id/et_nickname"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
                 android:autofillHints="@null"
                 android:background="@drawable/nickname_edittext"
                 android:gravity="center"

--- a/Android/FunBox/app/src/main/res/layout/fragment_quiz.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_quiz.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="vm"
             type="com.example.funbox.presentation.game.quiz.QuizViewModel" />
@@ -13,6 +14,101 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".presentation.game.quiz.QuizFragment">
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/question_answer_board_quiz"
+            android:layout_width="0dp"
+            android:layout_height="150dp"
+            android:layout_marginTop="-20dp"
+            app:cardBackgroundColor="@color/edittext_color"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="30dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/msg_question_quiz"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:text="@string/msg_question_quiz"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/question_quiz"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/example_question_quiz"
+                android:textSize="32sp"
+                android:textStyle="bold" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/example_question_answer_board_quiz"
+            android:layout_width="0dp"
+            android:layout_height="150dp"
+            android:layout_marginBottom="-20dp"
+            app:cardBackgroundColor="@color/edittext_color"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="30dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <EditText
+                    android:id="@+id/et_answer_quiz"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_weight="8"
+                    android:autofillHints="@null"
+                    android:background="@drawable/answer_edittext"
+                    android:inputType="textPersonName"
+                    android:onTextChanged="@{(answerValue, s, b, c) -> vm.validateAnswer(answerValue)}"
+                    android:padding="16dp"
+                    app:layout_constraintBottom_toTopOf="@id/btn_nickname"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_title_nickname"
+                    tools:ignore="LabelFor,SpeakableTextPresentCheck" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_nickname"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginEnd="32dp"
+                    android:layout_weight="2"
+                    android:background="@{(vm.quizUiState.isAnswerSubmitBtnEnable == true) ? @drawable/success_button : @drawable/fail_button}"
+                    android:enabled="@{vm.quizUiState.isAnswerSubmitBtnEnable}"
+                    android:onClick="@{() -> vm.submitAnswer()}"
+                    android:padding="16dp"
+                    android:text="@string/answer_submit"
+                    android:textColor="@{(vm.quizUiState.isAnswerSubmitBtnEnable == true) ? @color/white : @color/black}"
+                    android:textSize="24sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/et_nickname"
+                    tools:ignore="SpeakableTextPresentCheck" />
+
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
 
         <com.naver.maps.map.MapView
             android:id="@+id/map_view_game"

--- a/Android/FunBox/app/src/main/res/layout/fragment_wait.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_wait.xml
@@ -1,18 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="vm"
             type="com.example.funbox.presentation.game.wait.WaitViewModel" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/background_color"
         tools:context=".presentation.game.wait.WaitFragment">
 
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/user_info_wait"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="72dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="32dp"
+            android:background="@drawable/wait_background"
+            android:contentDescription="@string/user_wait_description"
+            app:cardBackgroundColor="@color/edittext_color"
+            app:cardCornerRadius="40dp"
+            app:cardElevation="10dp"
+            app:layout_constraintBottom_toTopOf="@id/side_info_wait"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/user_profile_wait"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top|center"
+                android:layout_margin="16dp"
+                android:background="@drawable/rounded_corner_rect_shadow"
+                android:contentDescription="@string/user_profile_wait_description"
+                android:elevation="10dp"
+                app:setImage="@{vm.waitUiState}" />
+
+            <TextView
+                android:id="@+id/user_id_wait"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/user_id_wait"
+                android:textSize="40sp" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/side_info_wait"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="72dp"
+            android:background="@drawable/wait_background"
+            android:contentDescription="@string/side_wait_description"
+            app:cardBackgroundColor="@color/edittext_color"
+            app:cardCornerRadius="40dp"
+            app:cardElevation="10dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/user_info_wait">
+
+            <ImageView
+                android:id="@+id/side_profile_wait"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top|center"
+                android:layout_margin="16dp"
+                android:background="@drawable/rounded_corner_rect_shadow"
+                android:contentDescription="@string/side_profile_wait_description"
+                android:elevation="10dp"
+                app:setImage="@{vm.waitUiState}" />
+
+            <TextView
+                android:id="@+id/side_id_wait"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/side_id_wait"
+                android:textSize="40sp" />
+
+            <TextView
+                android:id="@+id/msg_wait"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|center"
+                android:layout_margin="16dp"
+                android:text="@string/msg_wait"
+                android:textSize="32sp" />
+
+        </com.google.android.material.card.MaterialCardView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Android/FunBox/app/src/main/res/navigation/main_navi_graph.xml
+++ b/Android/FunBox/app/src/main/res/navigation/main_navi_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nvai_graph"
-    app:startDestination="@id/settingFragment">
+    app:startDestination="@id/WaitFragment">
 
     <fragment
         android:id="@+id/mapFragment"

--- a/Android/FunBox/app/src/main/res/navigation/main_navi_graph.xml
+++ b/Android/FunBox/app/src/main/res/navigation/main_navi_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nvai_graph"
-    app:startDestination="@id/WaitFragment">
+    app:startDestination="@id/QuizFragment">
 
     <fragment
         android:id="@+id/mapFragment"

--- a/Android/FunBox/app/src/main/res/values/strings.xml
+++ b/Android/FunBox/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="next">다음</string>
     <string name="no_next">X</string>
     <string name="submit">완료</string>
+    <string name="answer_submit">입력</string>
     <string name="nickname_setting_title">닉네임을 설정해주세요</string>
     <string name="profile_setting_title">프로필을 설정해주세요</string>
     <string name="description">매뉴</string>
@@ -21,6 +22,8 @@
     <string name="side_id_wait">상대 유저 아이디</string>
     <string name="msg_wait">대기중…</string>
     <string name="finish_wait">게임 시작</string>
+    <string name="msg_question_quiz">상대방과 만나 질문해주세요!</string>
+    <string name="example_question_quiz">저의 MBTI는 뭘까요?</string>
 
     <string name="iv_main_logo_description">FunBox 로고</string>
     <string name="btn_main_naver_login_description">NAVER 소셜 로그인 버튼</string>

--- a/Android/FunBox/app/src/main/res/values/strings.xml
+++ b/Android/FunBox/app/src/main/res/values/strings.xml
@@ -17,9 +17,17 @@
     <string name="social_login_info_naver_success">NAVER 로그인 성공</string>
     <string name="game_question_card_title">질문 카드</string>
     <string name="game_to_be_determined">To Be Continued…</string>
+    <string name="user_id_wait">유저 아이디</string>
+    <string name="side_id_wait">상대 유저 아이디</string>
+    <string name="msg_wait">대기중…</string>
+    <string name="finish_wait">게임 시작</string>
 
     <string name="iv_main_logo_description">FunBox 로고</string>
     <string name="btn_main_naver_login_description">NAVER 소셜 로그인 버튼</string>
     <string name="btn_add_profile_description">프로필 추가 버튼</string>
     <string name="btn_back_game_select_description">게임 선택 화면의 백 버튼</string>
+    <string name="user_wait_description">유저 대기 UI</string>
+    <string name="side_wait_description">상대 유저 대기 UI</string>
+    <string name="user_profile_wait_description">유저 프로필 사진</string>
+    <string name="side_profile_wait_description">상대 유저 프로필 사진</string>
 </resources>


### PR DESCRIPTION
# 제목
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
ex) feature-quizUI -> dev_and

### 변경사항
 - Naver Map 위에 MaterialCardView로 질문 및 답안 카드를 추가하였습니다.
 - 유저의 현재 상태에 따라 질문을 제시하는 입장이면 질문 카드가 출력되고, 답안을 맞추는 입장이면 답안 카드가 출력되게 구현할 예정이고, 지금은 UI만 구성하였습니다.
   - 질문 카드에는 상대방과 만나 질문해달라는 문구가 좌측 상단에 출력되고, 중앙에는 AI가 제시하는 질문 데이터를 받아 출력하도록 할 예정입니다.
   - 답안 카드에는 EditText와 입력 버튼을 추가하였으며, EditText의 Text가 비어있지 않을 경우에만 입력 버튼이 활성화됩니다. 입력 버튼을 누르면 서버에 Text를 답안으로써 데이터로 송신할 예정입니다.
   - 실행 화면

<p align="center">
   <img width=200 src="https://user-images.githubusercontent.com/55424662/284490882-973104d9-7b51-433a-9b5b-cdb647e0c924.gif">
</p>

Close: #80