### PR TITLE
Swagger 사용을 위한 초기 세팅 및 유저 모듈에 적용

### DIFF
--- a/BackEnd/funbox/.gitignore
+++ b/BackEnd/funbox/.gitignore
@@ -1,5 +1,3 @@
-/src/configs
-
 # compiled output
 /dist
 /node_modules

--- a/BackEnd/funbox/package-lock.json
+++ b/BackEnd/funbox/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^7.1.16",
         "@nestjs/typeorm": "^10.0.1",
         "mysql2": "^3.6.3",
         "reflect-metadata": "^0.1.13",
@@ -1659,6 +1660,25 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.3.tgz",
+      "integrity": "sha512-40Zdqg98lqoF0+7ThWIZFStxgzisK6GG22+1ABO4kZiGF/Tu2FE+DYLw+Q9D94vcFWizJ+MSjNN4ns9r6hIGxw==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "10.2.8",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.2.8.tgz",
@@ -1693,6 +1713,37 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.2"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.1.16.tgz",
+      "integrity": "sha512-f9KBk/BX9MUKPTj7tQNYJ124wV/jP5W2lwWHLGwe/4qQXixuDOo39zP55HIJ44LE7S04B7BOeUOo9GBJD/vRcw==",
+      "dependencies": {
+        "@nestjs/mapped-types": "2.0.3",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "5.9.1"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2672,8 +2723,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -6165,7 +6215,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6312,8 +6361,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -8180,6 +8228,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.9.1.tgz",
+      "integrity": "sha512-5zAx+hUwJb9T3EAntc7TqYkV716CMqG6sZpNlAAMOMWkNXRYxGkN8ADIvD55dQZ10LxN90ZM/TQmN7y1gpICnw=="
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",

--- a/BackEnd/funbox/package.json
+++ b/BackEnd/funbox/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.1.16",
     "@nestjs/typeorm": "^10.0.1",
     "mysql2": "^3.6.3",
     "reflect-metadata": "^0.1.13",

--- a/BackEnd/funbox/src/configs/swagger.config.ts
+++ b/BackEnd/funbox/src/configs/swagger.config.ts
@@ -1,0 +1,7 @@
+import { DocumentBuilder } from '@nestjs/swagger';
+
+export const swaggerConfig = new DocumentBuilder()
+  .setTitle('FunBox API Document')
+  .setDescription('FunBox 프로젝트의 API 문서입니다.')
+  .setVersion('1.0.0')
+  .build();

--- a/BackEnd/funbox/src/main.ts
+++ b/BackEnd/funbox/src/main.ts
@@ -1,8 +1,14 @@
 import { NestFactory } from '@nestjs/core';
+import { SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { swaggerConfig } from './configs/swagger.config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('api', app, document);
+
   await app.listen(3000);
 }
 bootstrap();

--- a/BackEnd/funbox/src/users/dto/near-users.dto.ts
+++ b/BackEnd/funbox/src/users/dto/near-users.dto.ts
@@ -1,7 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class NearUsersDto {
+    @ApiProperty({ description: 'id' })
     id: number;
+
+    @ApiProperty({ description: '이름' })
     username: string;
+
+    @ApiProperty({ description: '유저 위치 X좌표' })
     locX: number;
+
+    @ApiProperty({ description: '유저 위치 Y좌표' })
     locY: number;
+
+    @ApiProperty({ description: '1시간 내에 메시지가 변경된 경우 Ture' })
     isMsgInAnHour: boolean;
 }

--- a/BackEnd/funbox/src/users/dto/user-location.dto.ts
+++ b/BackEnd/funbox/src/users/dto/user-location.dto.ts
@@ -1,4 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class UserLocationDto {
+    @ApiProperty({ description: '유저 위치 X좌표' })
     locX: number;
+
+    @ApiProperty({ description: '유저 위치 Y좌표' })
     locY: number;
 }

--- a/BackEnd/funbox/src/users/dto/user-response.dto.ts
+++ b/BackEnd/funbox/src/users/dto/user-response.dto.ts
@@ -1,8 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { User } from "../user.entity";
 
 export class UserResponseDto {
+    @ApiProperty({ description: '이름' })
     name: string;
+
+    @ApiProperty({
+        example: 'https://picsum.photos/200',
+        description: '프로필 사진 URL',
+    })
     profileUrl: string;
+
+    @ApiProperty({ description: '유저 메시지' })
     message: string;
 
     static of(user: User): UserResponseDto {

--- a/BackEnd/funbox/src/users/user.entity.ts
+++ b/BackEnd/funbox/src/users/user.entity.ts
@@ -1,28 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()
 export class User extends BaseEntity {
     @PrimaryGeneratedColumn()
+    @ApiProperty({ description: 'id' })
     id: number;
 
     @Column({length: 15, nullable: true})
+    @ApiProperty({ description: '이름' })
     username: string;
 
     @Column({type: 'timestamp',nullable: false})
+    @ApiProperty({ description: '유저 생성 시간' })
     created_at: Date;
 
     @Column({length: 255, nullable: true})
+    @ApiProperty({
+        example: 'https://picsum.photos/200',
+        description: '프로필 사진 URL',
+    })
     profile_url: string;
 
     @Column({type: 'double', nullable: true})
+    @ApiProperty({ description: '유저 위치 X좌표' })
     locX: number;
 
     @Column({type: 'double', nullable: true})
+    @ApiProperty({ description: '유저 위치 Y좌표' })
     locY: number;
 
     @Column({length: 31, nullable: true})
+    @ApiProperty({ description: '유저 메시지' })
     message: string;
 
     @Column({type: 'timestamp',nullable: true})
+    @ApiProperty({ description: '메시지가 작성된 시간' })
     messaged_at: Date;
 }

--- a/BackEnd/funbox/src/users/user.entity.ts
+++ b/BackEnd/funbox/src/users/user.entity.ts
@@ -9,7 +9,7 @@ export class User extends BaseEntity {
     username: string;
 
     @Column({type: 'timestamp',nullable: false})
-    created_at: string;
+    created_at: Date;
 
     @Column({length: 255, nullable: true})
     profile_url: string;
@@ -24,5 +24,5 @@ export class User extends BaseEntity {
     message: string;
 
     @Column({type: 'timestamp',nullable: true})
-    messaged_at: string;
+    messaged_at: Date;
 }

--- a/BackEnd/funbox/src/users/users.controller.ts
+++ b/BackEnd/funbox/src/users/users.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { ApiTags, ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { User } from './user.entity';
 import { UserLocationDto } from './dto/user-location.dto';
@@ -6,32 +7,32 @@ import { NearUsersDto } from './dto/near-users.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 
 @Controller('users')
+@ApiTags('유저 API')
 export class UsersController {
     constructor(private usersService: UsersService) {}
 
-    @Get()
-    test(): string {
-        return "hello?";
-    }
-
-    @Get('/create')
+    @Post('/create')
+    @ApiCreatedResponse({ type: User })
     createUser(): Promise<User> {
         return this.usersService.createUsertest();
     }
 
-    @Post()
+    @Post('location')
+    @ApiOkResponse({ type: [NearUsersDto] })
     async updateUserLocationAndReturnNearUsers(@Body() userLocationDto: UserLocationDto): Promise<NearUsersDto[]> {
         await this.usersService.updateUserLocation(userLocationDto);
         return await this.usersService.findNearUsers(userLocationDto);
     }
   
     @Get('/:id')
+    @ApiOkResponse({ type: UserResponseDto })
     async getUserById(@Param('id') id: number): Promise<UserResponseDto> {
         const user = await this.usersService.getUserById(id)
         return UserResponseDto.of(user);
     }
 
     @Patch("/message")
+    @ApiOkResponse({ type: UserResponseDto })
     async updateUserMessage(
         @Body('message') message: string
     ): Promise<UserResponseDto> {

--- a/BackEnd/funbox/src/users/users.service.ts
+++ b/BackEnd/funbox/src/users/users.service.ts
@@ -8,12 +8,12 @@ export class UsersService {
     async createUsertest(): Promise<User> {
         const user = new User();
         user.username = "test";
-        user.created_at = "123123";
+        user.created_at = new Date();
         user.profile_url = "132123";
         user.locX = 123;
         user.locY = 123;
         user.message =  "hihi";
-        user.messaged_at = "123123";
+        user.messaged_at = new Date();
         return await user.save();
     }
 
@@ -59,6 +59,7 @@ export class UsersService {
     async updateUserMessage(id: number, message: string): Promise<User> {
         const user = await this.getUserById(id);
         user.message = message;
+        user.messaged_at = new Date();
         return await user.save();
     }
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
feature-swagger -> dev_back

### 변경사항
- Swagger 사용을 위한 초기 세팅:
API 문서 작성을 자동화하기 위해 Swagger를 세팅했습니다.
- User 엔티티의 timestamp 필드 타입 변경:
Swagger 테스트 과정에서 User API에 버그를 발견하여 수정했습니다.
- User 모듈에 Swagger 적용:
기존의 유저 모듈에 구현되어있던 API들을 Swagger로 가시화했습니다.

### 테스트 결과
<img width="1392" alt="스크린샷 2023-11-21 23 24 06" src="https://github.com/boostcampwm2023/and05-funbox/assets/42964952/ba69cbe3-e8a0-444d-a4f6-c3dc54d40cd3">

### 참고
- [NestJS에서 Swagger를 사용하는 방법](https://jhyeok.com/nestjs-swagger/)

