### PR TITLE
[feat] SharedPreferences 추가

### DIFF
--- a/Android/FunBox/app/src/main/AndroidManifest.xml
+++ b/Android/FunBox/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <application
+        android:name=".app.MyApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/app/MainApplication.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/app/MainApplication.kt
@@ -1,0 +1,28 @@
+package com.rpg.funbox.app
+
+import android.app.Application
+import android.content.Context
+import timber.log.Timber
+
+class MyApplication : Application() {
+
+    init {
+        instance = this
+    }
+
+    override fun onCreate() {
+        mySharedPreferences = MySharedPreferences()
+        super.onCreate()
+
+        Timber.plant(Timber.DebugTree())
+    }
+
+    companion object {
+        lateinit var mySharedPreferences: MySharedPreferences
+        var instance: MyApplication? = null
+
+        fun myContext(): Context {
+            return instance!!.applicationContext
+        }
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/app/MySharedPreferences.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/app/MySharedPreferences.kt
@@ -1,0 +1,18 @@
+package com.rpg.funbox.app
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class MySharedPreferences {
+
+    private val preferences: SharedPreferences =
+        MyApplication.myContext().getSharedPreferences("prefs_name", Context.MODE_PRIVATE)
+
+    fun getJWT(key: String, defValue: String): String {
+        return preferences.getString(key, defValue).toString()
+    }
+
+    fun setJWT(key: String, defValue: String) {
+        preferences.edit().putString(key, defValue).apply()
+    }
+}


### PR DESCRIPTION
# 제목
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
ex) feature-sharedPreferences -> dev_and

### 변경사항
 - 로그인 과정에서 서버에서 수신한 JWT 데이터를 로컬에 저장하고, 로드하여 서버에 송신함으로써 서버와 신뢰성 있는 통신을 하기 위하여 SharedPreferences를 사용하였습니다.
 - Application에서 SharedPreferences를 선언함으로써 앱 전역적으로 JWT 값을 get/set할 수 있도록 하였습니다.