### PR TITLE
[feat] 퀴즈 게임 UI 변경

### DIFF
--- a/Android/FunBox/app/src/main/AndroidManifest.xml
+++ b/Android/FunBox/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <application
+        android:name=".app.MyApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/app/MainApplication.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/app/MainApplication.kt
@@ -1,0 +1,28 @@
+package com.rpg.funbox.app
+
+import android.app.Application
+import android.content.Context
+import timber.log.Timber
+
+class MyApplication : Application() {
+
+    init {
+        instance = this
+    }
+
+    override fun onCreate() {
+        mySharedPreferences = MySharedPreferences()
+        super.onCreate()
+
+        Timber.plant(Timber.DebugTree())
+    }
+
+    companion object {
+        lateinit var mySharedPreferences: MySharedPreferences
+        var instance: MyApplication? = null
+
+        fun myContext(): Context {
+            return instance!!.applicationContext
+        }
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/app/MySharedPreferences.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/app/MySharedPreferences.kt
@@ -1,0 +1,18 @@
+package com.rpg.funbox.app
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class MySharedPreferences {
+
+    private val preferences: SharedPreferences =
+        MyApplication.myContext().getSharedPreferences("prefs_name", Context.MODE_PRIVATE)
+
+    fun getJWT(key: String, defValue: String): String {
+        return preferences.getString(key, defValue).toString()
+    }
+
+    fun setJWT(key: String, defValue: String) {
+        preferences.edit().putString(key, defValue).apply()
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/BaseDialogFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/BaseDialogFragment.kt
@@ -1,9 +1,12 @@
 package com.rpg.funbox.presentation
 
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.DialogFragment
@@ -19,6 +22,11 @@ abstract class BaseDialogFragment<T : ViewDataBinding>(private val layoutId: Int
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        dialog?.window?.run {
+            setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            requestFeature(Window.FEATURE_NO_TITLE)
+        }
+
         _binding = DataBindingUtil.inflate<T>(inflater, layoutId, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         return binding.root

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/CustomNaverMap.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/CustomNaverMap.kt
@@ -1,0 +1,40 @@
+package com.rpg.funbox.presentation
+
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
+import com.naver.maps.map.LocationTrackingMode
+import com.naver.maps.map.NaverMap
+import com.naver.maps.map.overlay.OverlayImage
+import com.naver.maps.map.util.FusedLocationSource
+import com.rpg.funbox.R
+
+object CustomNaverMap {
+
+    private const val MIN_ZOOM = 13.0
+    private const val MAX_ZOOM = 17.0
+    private const val SOUTH_WEST_LATITUDE = 31.43
+    private const val SOUTH_WEST_LONGITUDE = 122.37
+    private const val NORTH_EAST_LATITUDE = 44.35
+    private const val NORTH_EAST_LONGITUDE = 132.0
+
+    fun setNaverMap(naverMap: NaverMap, fusedLocationSource: FusedLocationSource): NaverMap {
+        naverMap.locationSource = fusedLocationSource
+        naverMap.locationTrackingMode = LocationTrackingMode.Face
+        naverMap.uiSettings.isLocationButtonEnabled = true
+
+        val locationOverlay = naverMap.locationOverlay
+        locationOverlay.isVisible = true
+        locationOverlay.icon = OverlayImage.fromResource(R.drawable.my_location)
+
+        naverMap.minZoom = MIN_ZOOM
+        naverMap.maxZoom = MAX_ZOOM
+        naverMap.uiSettings.isZoomControlEnabled = false
+        naverMap.extent = LatLngBounds(
+            LatLng(SOUTH_WEST_LATITUDE, SOUTH_WEST_LONGITUDE), LatLng(
+                NORTH_EAST_LATITUDE, NORTH_EAST_LONGITUDE
+            )
+        )
+
+        return naverMap
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizBindingAdapters.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizBindingAdapters.kt
@@ -1,3 +1,31 @@
 package com.rpg.funbox.presentation.game.quiz
 
+import android.view.View
 import androidx.databinding.BindingAdapter
+import com.google.android.material.card.MaterialCardView
+
+@BindingAdapter("app:answer_card_visible")
+fun MaterialCardView.bindAnswerVisibility(userQuizState: QuizUiState) {
+    visibility = when (userQuizState.isUserQuizState) {
+        true -> {
+            View.GONE
+        }
+
+        false -> {
+            View.VISIBLE
+        }
+    }
+}
+
+@BindingAdapter("app:quiz_card_visible")
+fun MaterialCardView.bindQuizVisibility(userQuizState: QuizUiState) {
+    visibility = when (userQuizState.isUserQuizState) {
+        true -> {
+            View.VISIBLE
+        }
+
+        false -> {
+            View.GONE
+        }
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizFragment.kt
@@ -5,76 +5,59 @@ import android.view.View
 import androidx.annotation.UiThread
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraUpdate
 import com.rpg.funbox.R
 import com.rpg.funbox.databinding.FragmentQuizBinding
 import com.rpg.funbox.presentation.BaseFragment
 import com.naver.maps.map.MapFragment
-import com.naver.maps.map.MapView
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.OnMapReadyCallback
+import com.naver.maps.map.util.FusedLocationSource
+import com.rpg.funbox.presentation.CustomNaverMap
+import com.rpg.funbox.presentation.login.AccessPermission
 
 class QuizFragment : BaseFragment<FragmentQuizBinding>(R.layout.fragment_quiz), OnMapReadyCallback {
 
     private val viewModel: QuizViewModel by activityViewModels()
-    private lateinit var mapView: MapView
+
+    private lateinit var quizMap: NaverMap
+    private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
+    private lateinit var fusedLocationSource: FusedLocationSource
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
-        mapView = binding.mapViewGame
-        mapView.onCreate(savedInstanceState)
-        setNaverMap()
+        fusedLocationProviderClient =
+            LocationServices.getFusedLocationProviderClient(requireActivity())
+
+        initNaverMap()
 
         collectLatestFlow(viewModel.quizUiEvent) { handleUiEvent(it) }
     }
 
-    override fun onStart() {
-        super.onStart()
-        mapView.onStart()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        mapView.onResume()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        mapView.onPause()
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        mapView.onSaveInstanceState(outState)
-    }
-
-    override fun onStop() {
-        super.onStop()
-        mapView.onStop()
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        mapView.onDestroy()
-    }
-
-    override fun onLowMemory() {
-        super.onLowMemory()
-        mapView.onLowMemory()
-    }
-
     @UiThread
-    override fun onMapReady(p0: NaverMap) {
+    override fun onMapReady(naverMap: NaverMap) {
+        quizMap = CustomNaverMap.setNaverMap(naverMap, fusedLocationSource)
 
+        quizMap.addOnLocationChangeListener { location ->
+            val cameraUpdate = CameraUpdate.scrollTo(LatLng(location.latitude, location.longitude))
+            naverMap.moveCamera(cameraUpdate)
+            viewModel.setLocation(location.latitude, location.longitude)
+        }
     }
 
-    private fun setNaverMap() {
+    private fun initNaverMap() {
         val cfm = childFragmentManager
-        val mapFragment = cfm.findFragmentById(R.id.map_view_game) as MapFragment?
+        val mapFragment = cfm.findFragmentById(R.id.map_view_quiz) as MapFragment?
             ?: MapFragment.newInstance().also { mapFragment ->
-                cfm.beginTransaction().add(R.id.map_view_game, mapFragment).commit()
+                cfm.beginTransaction().add(R.id.map_view_quiz, mapFragment).commit()
             }
         mapFragment.getMapAsync(this)
+        fusedLocationSource =
+            FusedLocationSource(this, AccessPermission.LOCATION_PERMISSION_REQUEST_CODE)
     }
 
     private fun handleUiEvent(event: QuizUiEvent) = when (event) {

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizUiState.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizUiState.kt
@@ -1,7 +1,13 @@
 package com.rpg.funbox.presentation.game.quiz
 
 data class QuizUiState(
-    val answerValidState: Boolean = false
+    val answerValidState: Boolean = false,
+    val userQuizState: UserQuizState = UserQuizState.Quiz
 ) {
     val isAnswerSubmitBtnEnable: Boolean = (answerValidState)
+    val isUserQuizState: Boolean = (userQuizState == UserQuizState.Quiz)
+}
+
+enum class UserQuizState {
+    Quiz, Answer
 }

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizViewModel.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizViewModel.kt
@@ -12,13 +12,21 @@ import timber.log.Timber
 
 class QuizViewModel : ViewModel() {
 
-    private val latestAnswer = MutableStateFlow<String>("")
+    private val _location = MutableStateFlow<Pair<Double, Double>?>(null)
+    val location = _location.asStateFlow()
+
+    private val _latestAnswer = MutableStateFlow<String>("")
+    val latestAnswer = _latestAnswer.asStateFlow()
 
     private val _quizUiEvent = MutableSharedFlow<QuizUiEvent>()
     val quizUiEvent = _quizUiEvent.asSharedFlow()
 
     private val _quizUiState = MutableStateFlow<QuizUiState>(QuizUiState())
     val quizUiState = _quizUiState.asStateFlow()
+
+    fun setLocation(x: Double, y: Double) {
+        _location.value = Pair(x, y)
+    }
 
     fun validateAnswer(answer: CharSequence) {
         if (answer.isBlank()) {
@@ -30,7 +38,7 @@ class QuizViewModel : ViewModel() {
                 uiState.copy(answerValidState = true)
             }
         }
-        latestAnswer.value = answer.toString()
+        _latestAnswer.value = answer.toString()
     }
 
     fun submitAnswer() {

--- a/Android/FunBox/app/src/main/res/layout/fragment_answer_check.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_answer_check.xml
@@ -15,6 +15,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@drawable/bg_dialog_rectangle"
+        android:backgroundTint="@null"
+        android:elevation="10dp"
         tools:context=".presentation.game.quiz.AnswerCheckFragment">
 
         <TextView
@@ -24,7 +26,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"
-            android:text="@string/answer_example"
+            android:text="@{vm.latestAnswer}"
             android:textSize="20sp"
             app:layout_constraintBottom_toTopOf="@id/tv_msg_answer_check"
             app:layout_constraintEnd_toEndOf="parent"

--- a/Android/FunBox/app/src/main/res/layout/fragment_profile.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_profile.xml
@@ -42,7 +42,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_title_profile"
-            app:profile_image_uri="@{vm.profileImageUri}" />
+            tools:profile_image_uri="@{vm.profileImageUri}" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_profile"

--- a/Android/FunBox/app/src/main/res/layout/fragment_quiz.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_quiz.xml
@@ -16,16 +16,17 @@
         tools:context=".presentation.game.quiz.QuizFragment">
 
         <com.google.android.material.card.MaterialCardView
-            android:id="@+id/question_answer_board_quiz"
+            android:id="@+id/question_board_quiz"
             android:layout_width="0dp"
             android:layout_height="150dp"
-            android:layout_marginTop="-20dp"
+            android:layout_marginTop="-32dp"
             app:cardBackgroundColor="@color/edittext_color"
-            app:cardCornerRadius="20dp"
+            app:cardCornerRadius="16dp"
             app:cardElevation="30dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            app:quiz_card_visible="@{vm.quizUiState}">
 
             <TextView
                 android:id="@+id/msg_question_quiz"
@@ -33,7 +34,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="start"
                 android:layout_marginStart="16dp"
-                android:layout_marginTop="32dp"
+                android:layout_marginTop="48dp"
                 android:text="@string/msg_question_quiz"
                 android:textStyle="bold" />
 
@@ -52,16 +53,17 @@
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
-            android:id="@+id/example_question_answer_board_quiz"
+            android:id="@+id/answer_board_quiz"
             android:layout_width="0dp"
             android:layout_height="150dp"
-            android:layout_marginBottom="-20dp"
+            android:layout_marginTop="-32dp"
+            app:answer_card_visible="@{vm.quizUiState}"
             app:cardBackgroundColor="@color/edittext_color"
-            app:cardCornerRadius="20dp"
+            app:cardCornerRadius="16dp"
             app:cardElevation="30dp"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -73,6 +75,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:layout_marginStart="32dp"
+                    android:layout_marginTop="16dp"
                     android:layout_marginEnd="16dp"
                     android:layout_weight="8"
                     android:autofillHints="@null"
@@ -91,6 +94,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
+                    android:layout_marginTop="12dp"
                     android:layout_marginEnd="32dp"
                     android:layout_weight="2"
                     android:background="@{(vm.quizUiState.isAnswerSubmitBtnEnable == true) ? @drawable/success_button : @drawable/fail_button}"
@@ -111,7 +115,7 @@
         </com.google.android.material.card.MaterialCardView>
 
         <com.naver.maps.map.MapView
-            android:id="@+id/map_view_game"
+            android:id="@+id/map_view_quiz"
             android:name="com.naver.maps.map.MapFragment"
             android:layout_width="0dp"
             android:layout_height="0dp"


### PR DESCRIPTION
# 제목
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
ex) feature-quizUI -> dev_and

### 변경사항
 - 퀴즈 게임의 UI를 변경하였습니다.
   - 현재 클라이언트가 문제를 내는 상태인지, 답안을 제출하는 상태인지를 열거형 클래스로 정의하고 그 상태를 UiState의 필드로 선언하여, 상태에 따라 다른 CardView가 출력되도록 하였습니다.
   - 또한 네이버 지도를 수정하여, 현재 클라이언트의 위치를 계속 추적할 수 있도록 하였습니다.
   - 실행 결과

<p align="center">
   <img width=200 src="https://user-images.githubusercontent.com/55424662/285754123-221a4415-549b-4ff8-aca3-099b62086c34.png">
   <img width=200 src="https://user-images.githubusercontent.com/55424662/285755281-3e3dd2e3-c46a-49ba-be7b-9c4370f430d5.gif">
</p>

Close: #110