### PR TITLE
[refactor] 퀴즈 게임 역할을 하는 GameActivity 추가, 관심사 분리

### DIFF
--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/MainActivity.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/MainActivity.kt
@@ -14,7 +14,7 @@ import com.rpg.funbox.presentation.game.quiz.QuizViewModel
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
-    private val quizViewModel: QuizViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/GameActivity.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/GameActivity.kt
@@ -1,0 +1,19 @@
+package com.rpg.funbox.presentation.game
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import androidx.activity.viewModels
+import com.rpg.funbox.R
+import com.rpg.funbox.databinding.ActivityGameBinding
+import com.rpg.funbox.presentation.game.quiz.QuizViewModel
+
+class GameActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityGameBinding
+    private val quizViewModel: QuizViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_game)
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizBindingAdapters.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizBindingAdapters.kt
@@ -1,31 +1,3 @@
 package com.rpg.funbox.presentation.game.quiz
 
-import android.view.View
 import androidx.databinding.BindingAdapter
-import com.google.android.material.card.MaterialCardView
-
-@BindingAdapter("app:answer_card_visible")
-fun MaterialCardView.bindAnswerVisibility(userQuizState: QuizUiState) {
-    visibility = when (userQuizState.isUserQuizState) {
-        true -> {
-            View.GONE
-        }
-
-        false -> {
-            View.VISIBLE
-        }
-    }
-}
-
-@BindingAdapter("app:quiz_card_visible")
-fun MaterialCardView.bindQuizVisibility(userQuizState: QuizUiState) {
-    visibility = when (userQuizState.isUserQuizState) {
-        true -> {
-            View.VISIBLE
-        }
-
-        false -> {
-            View.GONE
-        }
-    }
-}

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.UiThread
 import androidx.fragment.app.activityViewModels
-import androidx.navigation.fragment.findNavController
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.naver.maps.geometry.LatLng
@@ -78,7 +77,7 @@ class QuizFragment : BaseFragment<FragmentQuizBinding>(R.layout.fragment_quiz), 
         }
 
         is QuizUiEvent.QuizScoreBoard -> {
-            findNavController().navigate(R.id.action_QuizFragment_to_mapFragment)
+            requireActivity().finish()
         }
     }
 }

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizUiState.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/game/quiz/QuizUiState.kt
@@ -2,7 +2,7 @@ package com.rpg.funbox.presentation.game.quiz
 
 data class QuizUiState(
     val answerValidState: Boolean = false,
-    val userQuizState: UserQuizState = UserQuizState.Quiz
+    val userQuizState: UserQuizState = UserQuizState.Answer
 ) {
     val isAnswerSubmitBtnEnable: Boolean = (answerValidState)
     val isUserQuizState: Boolean = (userQuizState == UserQuizState.Quiz)

--- a/Android/FunBox/app/src/main/res/layout/activity_game.xml
+++ b/Android/FunBox/app/src/main/res/layout/activity_game.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="quizViewModel"
+            type="com.rpg.funbox.presentation.game.quiz.QuizViewModel" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.game.GameActivity">
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/game_nav_host_fragment"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:defaultNavHost="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:navGraph="@navigation/game_nav_graph" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/Android/FunBox/app/src/main/res/layout/fragment_quiz.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_quiz.xml
@@ -5,9 +5,12 @@
 
     <data>
 
+        <import type="android.view.View" />
+
         <variable
             name="vm"
             type="com.rpg.funbox.presentation.game.quiz.QuizViewModel" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -20,13 +23,13 @@
             android:layout_width="0dp"
             android:layout_height="150dp"
             android:layout_marginTop="-32dp"
+            android:visibility="@{vm.quizUiState.isUserQuizState ? View.VISIBLE : View.GONE}"
             app:cardBackgroundColor="@color/edittext_color"
             app:cardCornerRadius="16dp"
             app:cardElevation="30dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:quiz_card_visible="@{vm.quizUiState}">
+            app:layout_constraintTop_toTopOf="parent">
 
             <TextView
                 android:id="@+id/msg_question_quiz"
@@ -57,7 +60,7 @@
             android:layout_width="0dp"
             android:layout_height="150dp"
             android:layout_marginTop="-32dp"
-            app:answer_card_visible="@{vm.quizUiState}"
+            android:visibility="@{vm.quizUiState.isUserQuizState ? View.GONE : View.VISIBLE}"
             app:cardBackgroundColor="@color/edittext_color"
             app:cardCornerRadius="16dp"
             app:cardElevation="30dp"

--- a/Android/FunBox/app/src/main/res/navigation/game_nav_graph.xml
+++ b/Android/FunBox/app/src/main/res/navigation/game_nav_graph.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/game_nav_graph"
+    app:startDestination="@id/QuizFragment">
+
+    <fragment
+        android:id="@+id/WaitFragment"
+        android:name="com.rpg.funbox.presentation.game.wait.WaitFragment"
+        android:label="@string/fragment_wait_label"
+        tools:layout="WaitFragment">
+        <action
+            android:id="@+id/action_WaitFragment_to_QuizFragment"
+            app:destination="@id/QuizFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/QuizFragment"
+        android:name="com.rpg.funbox.presentation.game.quiz.QuizFragment"
+        android:label="@string/fragment_quiz_label"
+        tools:layout="QuizFragment" />
+
+</navigation>

--- a/Android/FunBox/app/src/main/res/navigation/main_navi_graph.xml
+++ b/Android/FunBox/app/src/main/res/navigation/main_navi_graph.xml
@@ -5,7 +5,6 @@
     android:id="@+id/nvai_graph"
     app:startDestination="@id/mapFragment">
 
-
     <fragment
         android:id="@+id/mapFragment"
         android:name="com.rpg.funbox.presentation.map.MapFragment"
@@ -21,37 +20,11 @@
         android:id="@+id/GameSelectFragment"
         android:name="com.rpg.funbox.presentation.game.gameselect.GameSelectFragment"
         tools:layout="GameSelectFragment">
-        <action
-            android:id="@+id/action_GameSelectFragment_to_WaitFragment"
-            app:destination="@id/WaitFragment"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim" />
         <argument
             android:name="otherID"
-            app:argType="integer"/>
+            app:argType="integer" />
     </fragment>
 
-    <fragment
-        android:id="@+id/WaitFragment"
-        android:name="com.rpg.funbox.presentation.game.wait.WaitFragment"
-        tools:layout="WaitFragment">
-        <action
-            android:id="@+id/action_WaitFragment_to_QuizFragment"
-            app:destination="@id/QuizFragment"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim" />
-    </fragment>
-
-    <fragment
-        android:id="@+id/QuizFragment"
-        android:name="com.rpg.funbox.presentation.game.quiz.QuizFragment"
-        tools:layout="QuizFragment">
-        <action
-            android:id="@+id/action_QuizFragment_to_mapFragment"
-            app:destination="@id/mapFragment"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim" />
-    </fragment>
     <fragment
         android:id="@+id/settingFragment"
         android:name="com.rpg.funbox.presentation.setting.SettingFragment"

--- a/Android/FunBox/app/src/main/res/values/strings.xml
+++ b/Android/FunBox/app/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="fragment_title_label">타이틀 화면</string>
     <string name="fragment_nickname_label">닉네임 입력</string>
     <string name="fragment_profile_label">프로필 설정</string>
+    <string name="fragment_wait_label">퀴즈 게임 대기</string>
+    <string name="fragment_quiz_label">퀴즈 게임</string>
     <string name="network_error_message">네트워크에 문제가 있습니다.</string>
     <string name="permission_message_toast">권한 허용이 필요합니다.</string>
     <string name="social_login_info_naver_client_name">네이버 아이디 로그인</string>


### PR DESCRIPTION
# 제목
### PR 타입
- [X] 기능 추가
- [X] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
feature-gameUIRefactor -> dev_and

### 변경사항
 - GameActivity를 추가하고 대기 및 퀴즈 게임 Fragment에 대한 NavHost의 역할을 할 수 있도록 하였습니다.
 - MainActivity에 존재하는 대기 및 퀴즈 게임과 관련된 View 및 ViewModel을 GameActivity와 Game NavGraph로 분리하였습니다.
 - 또한 CardView의 visibility에 대한 BindingAdapter를 제거하고 DataBinding 문법으로 클라이언트의 상태에 따라 다른 CardView가 출력되도록 변경하였습니다.