### PR TITLE
[refactor] Retrofit과 OkHttpClient 분리

### DIFF
--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/OkHttpClientInstance.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/OkHttpClientInstance.kt
@@ -1,0 +1,16 @@
+package com.rpg.funbox.data
+
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+
+object OkHttpClientInstance {
+
+    val okHttpClient: OkHttpClient by lazy {
+        val interceptor = HttpLoggingInterceptor()
+            .setLevel(HttpLoggingInterceptor.Level.BODY)
+        OkHttpClient.Builder().run {
+            this.addInterceptor(interceptor)
+            this.build()
+        }
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/RetrofitInstance.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/RetrofitInstance.kt
@@ -2,8 +2,6 @@ package com.rpg.funbox.data
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
@@ -14,19 +12,10 @@ object RetrofitInstance {
         .add(KotlinJsonAdapterFactory())
         .build()
 
-    private val okHttpClient: OkHttpClient by lazy {
-        val interceptor = HttpLoggingInterceptor()
-            .setLevel(HttpLoggingInterceptor.Level.BODY)
-        OkHttpClient.Builder().run {
-            this.addInterceptor(interceptor)
-            this.build()
-        }
-    }
-
     val retrofit: Retrofit by lazy {
         Retrofit.Builder()
             .baseUrl(FUNBOX_BASE_URL)
-            .client(okHttpClient)
+            .client(OkHttpClientInstance.okHttpClient)
             .addConverterFactory(MoshiConverterFactory.create(moshi))
             .build()
     }


### PR DESCRIPTION
# 제목
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
ex) feature-loginApi -> dev_and

### 변경사항
 - 재사용성을 고려하여 Retrofit과 OkHttpClient Object를 분리하였습니다.
 - 사실 Slack GitHub 연동 관련해서 테스트해보려고 PR 올렸습니다.