### PR TITLE
[feat] 로그인 및 지도 연동

### DIFF
--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/JWTInterceptor.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/JWTInterceptor.kt
@@ -13,7 +13,7 @@ object JWTInterceptor : Interceptor {
         val accessToken: String = MainApplication.mySharedPreferences.getJWT("jwt", "")
         Timber.d("JWTInterceptor: $accessToken")
         val newRequest = request().newBuilder()
-            .addHeader("authorization", accessToken)
+            .addHeader("Authorization", "Bearer $accessToken")
             .build()
         proceed(newRequest)
     }

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/JwtDecoder.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/JwtDecoder.kt
@@ -16,14 +16,8 @@ object JwtDecoder {
             String(Base64.decode(payloadJwt, Base64.DEFAULT), StandardCharsets.UTF_8)
         val jsonObject = JsonParser.parseString(decodedPayload).asJsonObject
 
-        var userName: String? = null
-        if (!jsonObject.get("username").isJsonNull) {
-            userName = jsonObject.get("username").asString
-        }
-
         return UserAuthDto(
             jsonObject.get("id").asInt,
-            userName,
             jsonObject.get("iat").asInt,
             jsonObject.get("exp").asInt
         )

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/OkHttpClientInstance.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/OkHttpClientInstance.kt
@@ -1,11 +1,11 @@
 package com.rpg.funbox.data
 
 import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 
 object OkHttpClientInstance {
 
     val okHttpClient: OkHttpClient by lazy {
-        // val interceptor = HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)
         OkHttpClient.Builder().run {
             this.addInterceptor(JWTInterceptor)
             this.build()

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UserAuthDto.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UserAuthDto.kt
@@ -6,9 +6,6 @@ data class UserAuthDto(
     @field:Json(name = "id")
     val id: Int,
 
-    @field:Json(name = "username")
-    val userName: String?,
-
     @field:Json(name = "iat")
     val iat: Int,
 

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UserInfoRequest.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UserInfoRequest.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 
 data class UserInfoRequest(
     @field:Json(name = "username")
-    val userName: String,
+    val username: String,
 
     @field:Json(name = "profileUrl")
     val profileUrl: String?,

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UserInfoResponse.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UserInfoResponse.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 
 data class UserInfoResponse(
     @field:Json(name = "username")
-    val userName: String,
+    val username: String?,
 
     @field:Json(name = "profileUrl")
     val profileUrl: String?,

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UserLocation.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UserLocation.kt
@@ -2,8 +2,8 @@ package com.rpg.funbox.data.dto
 
 data class UserLocation(
     val id: Int,
-    val username: String,
-    val locX: Double,
-    val locY: Double,
+    val username: String?,
+    val locX: Double?,
+    val locY: Double?,
     val isMsgInAnHour: Boolean
 )

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UsersLocationResponse.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UsersLocationResponse.kt
@@ -1,5 +1,5 @@
 package com.rpg.funbox.data.dto
 
 data class UsersLocationResponse(
-    val usersLocations: List<UserLocation>
+    val usersLocations: UserLocation
 )

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UsersLocationResponse.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/dto/UsersLocationResponse.kt
@@ -1,5 +1,0 @@
-package com.rpg.funbox.data.dto
-
-data class UsersLocationResponse(
-    val usersLocations: UserLocation
-)

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/network/service/SignUpApi.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/network/service/SignUpApi.kt
@@ -2,20 +2,28 @@ package com.rpg.funbox.data.network.service
 
 import com.rpg.funbox.data.dto.UserInfoRequest
 import com.rpg.funbox.data.dto.UserInfoResponse
+import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Part
 
 interface SignUpApi {
+
+    @GET("/users")
+    suspend fun fetchUserInfo(): Response<UserInfoResponse>
 
     @PATCH("/users/username")
     suspend fun submitUserName(
         @Body body: UserInfoRequest
     ): Response<UserInfoResponse>
 
+    @Multipart
     @POST("/users/profile")
-    suspend fun submitUserInfo(
-        @Body body: UserInfoRequest
+    suspend fun submitUserProfile(
+        @Part file: MultipartBody.Part
     ): Response<UserInfoResponse>
 }

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/network/service/UsersLocationApi.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/network/service/UsersLocationApi.kt
@@ -1,5 +1,6 @@
 package com.rpg.funbox.data.network.service
 
+import com.rpg.funbox.data.dto.UserLocation
 import com.rpg.funbox.data.dto.UsersLocationRequest
 import com.rpg.funbox.data.dto.UsersLocationResponse
 import retrofit2.Response
@@ -10,5 +11,5 @@ interface UsersLocationApi {
     @POST("/users/location")
     suspend fun fetchUsersLocation(
         @Body body: UsersLocationRequest
-    ) : Response<UsersLocationResponse>
+    ) : Response<List<UserLocation>>
 }

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/network/service/UsersLocationApi.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/network/service/UsersLocationApi.kt
@@ -2,7 +2,6 @@ package com.rpg.funbox.data.network.service
 
 import com.rpg.funbox.data.dto.UserLocation
 import com.rpg.funbox.data.dto.UsersLocationRequest
-import com.rpg.funbox.data.dto.UsersLocationResponse
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/repository/NaverLoginRepositoryImpl.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/repository/NaverLoginRepositoryImpl.kt
@@ -32,7 +32,7 @@ class NaverLoginRepositoryImpl : NaverLoginRepository {
                 if (body != null) {
                     Timber.d("JWT: ${body.accessToken}")
                 }
-                return UserAuthDto(0, null, 0, 0)
+                return UserAuthDto(0, 0, 0)
             }
 
             in serverErrorStatusCodeRange -> {}

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/repository/UserRepository.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/repository/UserRepository.kt
@@ -1,10 +1,12 @@
 package com.rpg.funbox.data.repository
 
+import okhttp3.MultipartBody
+
 interface UserRepository {
+
+    suspend fun getUserInfo(): String?
 
     suspend fun patchUserName(userName: String): Boolean
 
-    suspend fun postUserInfo(userName: String, profileUrl: String): Boolean
-
-    suspend fun getUserLocation(): String
+    suspend fun postUserProfile(imageFile: MultipartBody.Part): Boolean
 }

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/repository/UserRepositoryImpl.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/repository/UserRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.rpg.funbox.data.repository
 import com.rpg.funbox.data.RetrofitInstance
 import com.rpg.funbox.data.dto.UserInfoRequest
 import com.rpg.funbox.data.network.service.SignUpApi
+import okhttp3.MultipartBody
 import timber.log.Timber
 
 class UserRepositoryImpl : UserRepository {
@@ -11,9 +12,22 @@ class UserRepositoryImpl : UserRepository {
         RetrofitInstance.retrofit.create(SignUpApi::class.java)
     }
 
+    override suspend fun getUserInfo(): String? {
+        val response = signUpApi.fetchUserInfo()
+        when (response.code()) {
+            in successStatusCodeRange -> {
+                return response.body()?.username
+            }
+
+            else -> {}
+        }
+
+        return null
+    }
+
     override suspend fun patchUserName(userName: String): Boolean {
-        val response = signUpApi.submitUserName(UserInfoRequest(userName, null, null))
-        Timber.d("Code: ${response.code()}")
+        val response = signUpApi.submitUserName(UserInfoRequest(username = userName, null, null))
+        Timber.d("Post User Name: ${response.code()}")
         when (response.code()) {
             in successStatusCodeRange -> {
                 Timber.d("Post UserName: ${response.body()}")
@@ -26,13 +40,17 @@ class UserRepositoryImpl : UserRepository {
         return false
     }
 
-    override suspend fun postUserInfo(userName: String, profileUrl: String): Boolean {
-        val response = signUpApi.submitUserInfo(UserInfoRequest(userName, profileUrl, null))
-        return true
-    }
+    override suspend fun postUserProfile(imageFile: MultipartBody.Part): Boolean {
+        val response = signUpApi.submitUserProfile(file = imageFile)
+        Timber.d("Post User Profile: ${response.code()}")
+        when (response.code()) {
+            in successStatusCodeRange -> {
+                return true
+            }
 
-    override suspend fun getUserLocation(): String {
-        return ""
+            else -> {}
+        }
+        return false
     }
 
     companion object {

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/repository/UsersLocationRepository.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/repository/UsersLocationRepository.kt
@@ -4,5 +4,5 @@ import com.rpg.funbox.data.dto.UserLocation
 
 interface UsersLocationRepository {
 
-    suspend fun getUsersLocation(): List<UserLocation>?
+    suspend fun getUsersLocation(locX: Double, locY: Double): List<UserLocation>?
 }

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/data/repository/UsersLocationRepositoryImpl.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/data/repository/UsersLocationRepositoryImpl.kt
@@ -4,7 +4,6 @@ import com.rpg.funbox.data.RetrofitInstance
 import com.rpg.funbox.data.dto.UserLocation
 import com.rpg.funbox.data.dto.UsersLocationRequest
 import com.rpg.funbox.data.network.service.UsersLocationApi
-import timber.log.Timber
 
 class UsersLocationRepositoryImpl : UsersLocationRepository {
 
@@ -12,17 +11,15 @@ class UsersLocationRepositoryImpl : UsersLocationRepository {
         RetrofitInstance.retrofit.create(UsersLocationApi::class.java)
     }
 
-    override suspend fun getUsersLocation(): List<UserLocation>? {
-        val response = usersLocationApi.fetchUsersLocation(UsersLocationRequest(0.0, 0.0))
+    override suspend fun getUsersLocation(locX: Double, locY: Double): List<UserLocation>? {
+        val response = usersLocationApi.fetchUsersLocation(UsersLocationRequest(locX = locX, locY = locY))
 
         when (response.code()) {
             in successStatusCodeRange -> {
-                Timber.d("${response.body()}")
+                return response.body()
             }
 
-            UNAUTHORIZED_STATUS -> {
-                Timber.d("${response.code()}")
-            }
+            UNAUTHORIZED_STATUS -> {}
 
             in serverErrorStatusCodeRange -> {}
 

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/CheckPermission.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/CheckPermission.kt
@@ -1,0 +1,10 @@
+package com.rpg.funbox.presentation
+
+import android.app.Activity
+import android.content.pm.PackageManager
+
+fun Activity.checkPermission(permissions: Array<String>): Boolean {
+    return permissions.all { permission ->
+        checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/login/profile/ProfileFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/login/profile/ProfileFragment.kt
@@ -1,33 +1,38 @@
 package com.rpg.funbox.presentation.login.profile
 
+import android.annotation.SuppressLint
+import android.app.Activity.RESULT_OK
 import android.content.Intent
+import android.database.Cursor
+import android.net.Uri
 import android.os.Bundle
+import android.provider.MediaStore
 import android.view.View
-import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.activityViewModels
 import com.rpg.funbox.R
 import com.rpg.funbox.databinding.FragmentProfileBinding
 import com.rpg.funbox.presentation.BaseFragment
 import com.rpg.funbox.presentation.MainActivity
-import com.rpg.funbox.presentation.login.AccessPermission
 import com.rpg.funbox.presentation.login.title.TitleViewModel
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
 
+@SuppressLint("IntentReset")
 class ProfileFragment : BaseFragment<FragmentProfileBinding>(R.layout.fragment_profile) {
 
     private val viewModel: TitleViewModel by activityViewModels()
-    private val profileImagePicker =
-        registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
-            this.viewModel.selectProfile(uri)
-        }
-    private val requestMultiPermissions =
-        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
-            var flag = true
-            it.entries.forEach { entry ->
-                flag = entry.value
-            }
-            if (flag) {
-                profileImagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+    private var launcher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == RESULT_OK) {
+                val imagePath = result.data?.data
+                val file = File(absolutelyPath(imagePath))
+                val requestFile = file.asRequestBody("image/*".toMediaTypeOrNull())
+                val body = MultipartBody.Part.createFormData("file", file.name, requestFile)
+
+                viewModel.selectProfile(imagePath, body)
             }
         }
 
@@ -38,9 +43,28 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>(R.layout.fragment_p
         collectLatestFlow(viewModel.profileUiEvent) { handleUiEvent(it) }
     }
 
+    private fun getProfileImage() {
+        val chooserIntent = Intent(Intent.ACTION_CHOOSER)
+        val intent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+        intent.type = "image/*"
+        chooserIntent.putExtra(Intent.EXTRA_INTENT, intent)
+        chooserIntent.putExtra(Intent.EXTRA_TITLE, resources.getString(R.string.msg_select_picture))
+        launcher.launch(chooserIntent)
+    }
+
+    private fun absolutelyPath(uri: Uri?): String {
+        val proj: Array<String> = arrayOf(MediaStore.Images.Media.DATA)
+        val cursor: Cursor? =
+            uri?.let { requireActivity().contentResolver.query(it, proj, null, null, null) }
+        val index = cursor?.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
+        cursor?.moveToFirst()
+
+        return cursor!!.getString(index!!)
+    }
+
     private fun handleUiEvent(event: ProfileUiEvent) = when (event) {
         is ProfileUiEvent.ProfileSelect -> {
-            requestMultiPermissions.launch(AccessPermission.profilePermissionList)
+            getProfileImage()
         }
 
         is ProfileUiEvent.ProfileSubmit -> {

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/login/splash/SplashActivity.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/login/splash/SplashActivity.kt
@@ -4,23 +4,52 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority.PRIORITY_HIGH_ACCURACY
 import com.rpg.funbox.presentation.MainActivity
+import com.rpg.funbox.presentation.checkPermission
+import com.rpg.funbox.presentation.login.AccessPermission
 import com.rpg.funbox.presentation.login.TitleActivity
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 @SuppressLint("CustomSplashScreen")
 class SplashActivity : AppCompatActivity() {
 
     private val viewModel: SplashViewModel by viewModels()
+    private lateinit var fusedLocationClient: FusedLocationProviderClient
+    private val requestMultiPermissions =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {}
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        requestLocationPermissions()
+        collectLatestUiEvent()
+    }
+
+    private fun requestLocationPermissions() {
+        requestMultiPermissions.launch(AccessPermission.locationPermissionList)
+        if (checkPermission(AccessPermission.locationPermissionList)) {
+            fusedLocationClient = LocationServices.getFusedLocationProviderClient(this@SplashActivity)
+        } else {
+            finish()
+        }
         lifecycleScope.launch {
-            viewModel.getUsersLocations()
+            val tmp = fusedLocationClient.getCurrentLocation(PRIORITY_HIGH_ACCURACY, null).await()
+            if (tmp != null) {
+                viewModel.getUsersLocations(tmp.latitude, tmp.longitude)
+            }
+        }
+    }
+
+    private fun collectLatestUiEvent() {
+        lifecycleScope.launch {
             viewModel.splashUiEvent.collectLatest { splashUiEvent ->
                 when (splashUiEvent) {
                     is SplashUiEvent.Unauthorized -> {

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/login/splash/SplashViewModel.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/login/splash/SplashViewModel.kt
@@ -2,6 +2,8 @@ package com.rpg.funbox.presentation.login.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rpg.funbox.data.repository.UserRepository
+import com.rpg.funbox.data.repository.UserRepositoryImpl
 import com.rpg.funbox.data.repository.UsersLocationRepository
 import com.rpg.funbox.data.repository.UsersLocationRepositoryImpl
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -11,18 +13,27 @@ import kotlinx.coroutines.launch
 class SplashViewModel : ViewModel() {
 
     private val usersLocationRepository: UsersLocationRepository = UsersLocationRepositoryImpl()
+    private val userRepository: UserRepository = UserRepositoryImpl()
 
     private val _splashUiEvent = MutableSharedFlow<SplashUiEvent>()
     val splashUiEvent = _splashUiEvent.asSharedFlow()
 
-    fun getUsersLocations() {
+    private fun validateUserName(userName: String?): Boolean {
+        return (userName != null)
+    }
+
+    fun getUsersLocations(locX: Double, locY: Double) {
         viewModelScope.launch {
-            when (usersLocationRepository.getUsersLocation()) {
+            when (usersLocationRepository.getUsersLocation(locX, locY)) {
                 null -> {
                     _splashUiEvent.emit(SplashUiEvent.Unauthorized)
                 }
                 else -> {
-                    _splashUiEvent.emit(SplashUiEvent.GetUsersLocationsSuccess)
+                    if (validateUserName(userRepository.getUserInfo())) {
+                        _splashUiEvent.emit(SplashUiEvent.GetUsersLocationsSuccess)
+                    } else {
+                        _splashUiEvent.emit(SplashUiEvent.Unauthorized)
+                    }
                 }
             }
         }

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/login/title/TitleFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/login/title/TitleFragment.kt
@@ -34,6 +34,7 @@ class TitleFragment : BaseFragment<FragmentTitleBinding>(R.layout.fragment_title
             getString(R.string.naver_login_secret_key),
             getString(R.string.social_login_info_naver_client_name)
         )
+        // NaverIdLoginSDK.logout()
     }
 
     private fun loginAuthenticate() {

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/map/MapFragment.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/map/MapFragment.kt
@@ -9,14 +9,17 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.view.View
-import androidx.core.app.ActivityCompat
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.UiThread
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.geometry.LatLngBounds
 import com.naver.maps.map.CameraUpdate
@@ -31,9 +34,18 @@ import com.naver.maps.map.util.FusedLocationSource
 import com.rpg.funbox.R
 import com.rpg.funbox.databinding.FragmentMapBinding
 import com.rpg.funbox.presentation.BaseFragment
+import com.rpg.funbox.presentation.checkPermission
+import com.rpg.funbox.presentation.login.AccessPermission
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Timer
+import kotlin.concurrent.scheduleAtFixedRate
 
 class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnMapReadyCallback {
 
@@ -50,6 +62,10 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
         Manifest.permission.ACCESS_FINE_LOCATION,
         Manifest.permission.ACCESS_COARSE_LOCATION
     )
+
+    private val requestMultiPermissions =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {}
+
     private fun handleUiEvent(event: MapUiEvent) = when (event) {
         is MapUiEvent.MessageOpen -> {
             MessageDialog().show(parentFragmentManager, "messageDialog")
@@ -65,22 +81,25 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
             GetGameDialog().show(parentFragmentManager, "getGame")
         }
 
-        is MapUiEvent.ToSetting ->{
+        is MapUiEvent.ToSetting -> {
             findNavController().navigate(R.id.action_mapFragment_to_settingFragment)
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle?){
+    override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (!hasPermission()) {
-            ActivityCompat.requestPermissions(requireActivity(), PERMISSIONS, LOCATION_PERMISSION_REQUEST_CODE)
-        }
+//        if (!hasPermission()) {
+//            ActivityCompat.requestPermissions(
+//                requireActivity(),
+//                PERMISSIONS,
+//                LOCATION_PERMISSION_REQUEST_CODE
+//            )
+//        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
-        fusedLocationClient = LocationServices.getFusedLocationProviderClient(requireActivity())
 
         collectLatestFlow(viewModel.mapUiEvent) { handleUiEvent(it) }
 
@@ -88,8 +107,24 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
             toggleFab()
         }
 
-        viewModel.mapApi()
-        initMapView()
+        // viewModel.mapApi()
+        requestMultiPermissions.launch(AccessPermission.locationPermissionList)
+        if (requireActivity().checkPermission(AccessPermission.locationPermissionList)) {
+            fusedLocationClient = LocationServices.getFusedLocationProviderClient(requireActivity())
+        } else {
+            requireActivity().finish()
+        }
+
+        Timer().scheduleAtFixedRate(0, 3000) {
+            lifecycleScope.launch {
+                val tmp = runBlocking {
+                    fusedLocationClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null).await()
+                }
+                Timber.d("Now: ${LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}, Locations: $tmp")
+                viewModel.setUsersLocations(tmp.latitude, tmp.longitude)
+                initMapView()
+            }
+        }
     }
 
     override fun onStart() {
@@ -139,6 +174,7 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
         isFabOpen = !isFabOpen
     }
 
+    @UiThread
     override fun onMapReady(map: NaverMap) {
         this.naverMap = map
         map.locationSource = locationSource
@@ -154,12 +190,12 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
         naverMap.addOnLocationChangeListener { location ->
             val cameraUpdate = CameraUpdate.scrollTo(LatLng(location.latitude, location.longitude))
             naverMap.moveCamera(cameraUpdate)
-            viewModel.setXY(location.latitude,location.longitude)
+            // viewModel.setUsersLocations(location.latitude, location.longitude)
         }
 
-        naverMap.minZoom = 13.0
-        naverMap.maxZoom = 17.0
-        naverMap.uiSettings.isZoomControlEnabled = false
+        naverMap.minZoom = 5.0
+        naverMap.maxZoom = 20.0
+        naverMap.uiSettings.isZoomControlEnabled = true
         naverMap.extent = LatLngBounds(LatLng(31.43, 122.37), LatLng(44.35, 132.0))
 
         val hasMsg = InfoWindow()
@@ -182,10 +218,11 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
         }
 
         viewModel.users.value.map { user ->
-            var adapter  = MapProfileAdapter(requireContext(),viewModel.userDetail.value,null)
+            var adapter = MapProfileAdapter(requireContext(), viewModel.userDetail.value, null)
             val marker = Marker().apply {
+                Timber.d("User: ${user.id}")
                 position = user.loc
-                iconTintColor = Color.RED
+                iconTintColor = Color.YELLOW
                 this.map = naverMap
                 captionText = user.name.toString()
                 captionTextSize = 20F
@@ -198,37 +235,38 @@ class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnM
 
 
 
-                runBlocking {
-                    val test = viewModel.userDetail.value.profile
-                    val image : Bitmap = try {
-                        withContext(Dispatchers.IO) {
-                            Glide.with(requireContext())
-                                .asBitmap()
-                                .load(test)
-                                .apply(RequestOptions().override(100, 100))
-                                .submit()
-                                .get()
+                    runBlocking {
+                        val test = viewModel.userDetail.value.profile
+                        val image: Bitmap = try {
+                            withContext(Dispatchers.IO) {
+                                Glide.with(requireContext())
+                                    .asBitmap()
+                                    .load(test)
+                                    .apply(RequestOptions().override(100, 100))
+                                    .submit()
+                                    .get()
+                            }
+                        } catch (e: Exception) {
+                            withContext(Dispatchers.IO) {
+                                Glide.with(requireContext())
+                                    .asBitmap()
+                                    .load(R.drawable.close_24)
+                                    .apply(RequestOptions().override(100, 100))
+                                    .submit()
+                                    .get()
+                            }
                         }
-                    }catch (e: Exception){
-                        withContext(Dispatchers.IO) {
-                            Glide.with(requireContext())
-                                .asBitmap()
-                                .load(R.drawable.close_24)
-                                .apply(RequestOptions().override(100, 100))
-                                .submit()
-                                .get()
-                        }
-                    }
 
-                    adapter = MapProfileAdapter(requireContext(), viewModel.userDetail.value, image)
-                }
+                        adapter =
+                            MapProfileAdapter(requireContext(), viewModel.userDetail.value, image)
+                    }
 
 
                     requireActivity().runOnUiThread {
                         Handler(Looper.getMainLooper()).postDelayed({
                             infoWindow.adapter = adapter
                             infoWindow.open(this)
-                        },500)
+                        }, 500)
                     }
 
 

--- a/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/map/MapViewModel.kt
+++ b/Android/FunBox/app/src/main/java/com/rpg/funbox/presentation/map/MapViewModel.kt
@@ -1,37 +1,44 @@
 package com.rpg.funbox.presentation.map
 
-import android.graphics.ImageDecoder
-import android.provider.MediaStore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rpg.funbox.data.dto.User
 import com.rpg.funbox.data.dto.UserDetail
-import com.rpg.funbox.presentation.login.nickname.NicknameUiEvent
 import com.naver.maps.geometry.LatLng
+import com.rpg.funbox.data.dto.UserLocation
+import com.rpg.funbox.data.repository.UsersLocationRepository
+import com.rpg.funbox.data.repository.UsersLocationRepositoryImpl
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class MapViewModel : ViewModel() {
+
+    private val usersLocationRepository: UsersLocationRepository = UsersLocationRepositoryImpl()
+
     private val _myMessage = MutableStateFlow("")
     val myMessage: StateFlow<String> = _myMessage
-    private val locX : MutableStateFlow<Double?>  = MutableStateFlow(null)
-    private val locY : MutableStateFlow<Double?>  = MutableStateFlow(null)
+    private val locX: MutableStateFlow<Double?> = MutableStateFlow(null)
+    private val locY: MutableStateFlow<Double?> = MutableStateFlow(null)
 
     private val _users = MutableStateFlow(listOf<User>())
     val users: StateFlow<List<User>> = _users
 
-    private val _userDetail= MutableStateFlow(UserDetail(0,"","",""))
-    val userDetail : StateFlow<UserDetail> = _userDetail
+    private val _usersLocations = MutableStateFlow<List<UserLocation>?>(null)
+    val usersLocations = _usersLocations.asStateFlow()
+
+    private val _userDetail = MutableStateFlow(UserDetail(0, "", "", ""))
+    val userDetail: StateFlow<UserDetail> = _userDetail
 
     private val _mapUiEvent = MutableSharedFlow<MapUiEvent>()
     val mapUiEvent = _mapUiEvent.asSharedFlow()
 
-    private val _visibility= MutableStateFlow(false)
-    val visibility : StateFlow<Boolean> = _visibility
+    private val _visibility = MutableStateFlow(false)
+    val visibility: StateFlow<Boolean> = _visibility
 
     fun startMessageDialog() {
         viewModelScope.launch {
@@ -39,30 +46,63 @@ class MapViewModel : ViewModel() {
         }
     }
 
-    fun toGame(){
+    fun toGame() {
         viewModelScope.launch {
             _mapUiEvent.emit(MapUiEvent.ToGame)
         }
     }
 
-    fun getGame(){
+    fun getGame() {
         viewModelScope.launch {
             _mapUiEvent.emit(MapUiEvent.GetGame)
         }
     }
 
-    fun toSetting(){
+    fun toSetting() {
         viewModelScope.launch {
             _mapUiEvent.emit(MapUiEvent.ToSetting)
         }
     }
 
-    fun setXY(x:Double,y:Double){
+    fun setXY(x: Double, y: Double) {
         locX.update {
             x
         }
         locY.update {
             y
+        }
+    }
+
+    fun setUsersLocations(locX: Double, locY: Double) {
+        viewModelScope.launch {
+            _usersLocations.value = usersLocationRepository.getUsersLocation(locX, locY)
+            _usersLocations.value?.let { list ->
+                val newUsers = mutableListOf<User>()
+                list.forEach { location ->
+                    if ((location.locX != null) && (location.locY != null)) {
+                        newUsers.add(
+                            User(
+                                200,
+                                location.id,
+                                LatLng(location.locX, location.locY),
+                                location.username,
+                                false
+                            )
+                        )
+                    } else {
+                        newUsers.add(
+                            User(
+                                200,
+                                location.id,
+                                LatLng(37.6500000, 126.7800000),
+                                location.username,
+                                false
+                            )
+                        )
+                    }
+                }
+                _users.value = newUsers
+            }
         }
     }
 
@@ -89,7 +129,7 @@ class MapViewModel : ViewModel() {
                 User(
                     200,
                     3,
-                    LatLng(37.2435914,127.0730043),
+                    LatLng(37.2435914, 127.0730043),
                     "C",
                     true
                 )
@@ -97,17 +137,22 @@ class MapViewModel : ViewModel() {
         }
     }
 
-    fun userDetailApi(id:Int){
+    fun userDetailApi(id: Int) {
         _userDetail.update {
-            UserDetail( id,"안녕하세요","https://drive.google.com/file/d/1P6Va6qkB39gnE-gbfbPLCSxIFwAeM8Ul/view?usp=drive_link", "B")
+            UserDetail(
+                id,
+                "안녕하세요",
+                "https://drive.google.com/file/d/1P6Va6qkB39gnE-gbfbPLCSxIFwAeM8Ul/view?usp=drive_link",
+                "B"
+            )
         }
     }
 
-    fun buttonVisible(){
+    fun buttonVisible() {
         _visibility.update { true }
     }
 
-    fun buttonGone(){
+    fun buttonGone() {
         _visibility.update { false }
     }
 }

--- a/Android/FunBox/app/src/main/res/layout/fragment_profile.xml
+++ b/Android/FunBox/app/src/main/res/layout/fragment_profile.xml
@@ -52,7 +52,7 @@
             android:layout_marginTop="32dp"
             android:layout_marginEnd="120dp"
             android:background="@{(vm.profileUiState.isBtnProfileEnable == true) ? @drawable/success_button : @drawable/fail_button}"
-            android:onClick="@{() -> vm.submitSelectProfile()}"
+            android:onClick="@{() -> vm.submitProfile()}"
             android:text="@string/submit"
             android:textColor="@{(vm.profileUiState.isBtnProfileEnable == true) ? @color/white : @color/black}"
             android:textSize="24sp"

--- a/Android/FunBox/app/src/main/res/values/strings.xml
+++ b/Android/FunBox/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="score_board_title">점수창</string>
     <string name="score">2</string>
     <string name="colon">:</string>
+    <string name="msg_select_picture">사진을 선택해주세요!</string>
 
     <string name="iv_main_logo_description">FunBox 로고</string>
     <string name="btn_main_naver_login_description">NAVER 소셜 로그인 버튼</string>


### PR DESCRIPTION
# 제목
### PR 타입
- [X] 기능 추가
- [X] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
ex) feature-loginApi -> dev_and

### 변경사항
 - JWT Decode 로직 수정
 - 이미지의 URI가 아닌 File 형식으로 가져오도록 변경
   - File을 Multipart를 사용하여 서버에 전송하기 위해 변경
 - API 통신 코드 추가
   - 자신의 정보를 가져올 수 있는 GET 방식의 Users
   - 자신의 현재 위치를 전송하고 유저들의 위치 정보를 List로 수신하는 POST 방식의 Users Location
 - 유저 위치 정보에 해당하는 데이터 클래스의 일부 필드 변경
   - DB에 username, location X Y가 nullable한 값으로 저장되어 있음
 - Users Location 통신 관련 로직 수정
   - Response의 body를 List의 형태로 변경
 - Splash Screen에서 Users Location 후 Users로 사용자 유저 정보 불러와서 닉네임 검사
 - 사용자의 위치 정보를 3초마다 제공하고 받아온 위치 정보 데이터를 토대로 마커를 새로 출력
 - 실행 결과

<div align="center">

|회원 가입으로 이동|로그인 성공 이후 메인 화면으로 바로 이동|
|:--:|:--:|
|<p><img width=200 src="https://user-images.githubusercontent.com/55424662/287138698-29bab78e-52b3-4b28-940b-2d18cf69e3bd.gif"></p>|<p><img width=200 src="https://user-images.githubusercontent.com/55424662/287138494-78287a0c-1a25-47d4-8b7f-0db32c3438f7.gif"></p>|

</div>