### PR TITLE
[fix] 유저 탈퇴 한 후 재로그인 시 500 에러 뜨던 것 수정

### DIFF
--- a/BackEnd/funbox/src/auth/jwt.strategy.ts
+++ b/BackEnd/funbox/src/auth/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { User } from 'src/users/user.entity';
@@ -15,12 +15,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload) {
     const { id } = payload;
-    const userAuthDto = UserAuthDto.of(
-      await User.findOne({ where: { id: id } }),
-    );
-    if (!userAuthDto) {
-      throw new NotFoundException('there is not that user');
+    const user = await User.findOne({ where: { id: id } });
+    if (!user) {
+      throw new UnauthorizedException('there is not that user');
     }
-    return userAuthDto;
+    return UserAuthDto.of(user);
   }
 }


### PR DESCRIPTION
# [fix] 유저 탈퇴 한 후 재로그인 시 500 에러 뜨던 것 수정
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
fix_auth01 -> dev_back

### 변경사항
* DB 상에서 id는 없는데 jwt는 유효해서 생기는 문제
      - id가 없으면 401에러 뜨도록 수정

### 테스트 결과
* 기존 결과
  ```
  [Nest] 107567  - 12/07/2023, 4:30:52 PM   ERROR [ExceptionsHandler] Cannot read properties of null (reading 'id')
    TypeError: Cannot read properties of null (reading 'id')
    at Function.of (/home/k33ps/Desktop/boost/funbox/BackEnd/funbox/src/auth/dto/user-auth.dto.ts:9:23)
    at JwtStrategy.validate (/home/k33ps/Desktop/boost/funbox/BackEnd/funbox/src/auth/jwt.strategy.ts:18:37)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at JwtStrategy.callback [as _verify] 
    (/home/k33ps/Desktop/boost/funbox/BackEnd/funbox/node_modules/@nestjs/passport/dist/passport/passport.strategy.js:11:44)
  ```
* 변경 후 : 잘 됨!
  ```
  {
  "message": "Unauthorized",
  "statusCode": 401
  }
  ```

