### PR TITLE
[fix] 게임 로직 피드백 반영

### DIFF
--- a/BackEnd/funbox/src/socket/enum/game-apply-answer.enum.ts
+++ b/BackEnd/funbox/src/socket/enum/game-apply-answer.enum.ts
@@ -1,5 +1,6 @@
 export enum GameApplyAnswer {
   OFFLINE = 'OFFLINE',
+  PLAYING = 'PLAYING',
   ACCEPT = 'ACCEPT',
   REJECT = 'REJECT',
 }

--- a/BackEnd/funbox/src/socket/socket.service.ts
+++ b/BackEnd/funbox/src/socket/socket.service.ts
@@ -104,7 +104,7 @@ export class SocketService {
   getRoomId(client: Socket): string {
     const roomId = client.data.roomId;
     if (!roomId) {
-      throw new BadRequestException();
+      throw new BadRequestException("Client isn't in game");
     }
     return roomId;
   }

--- a/BackEnd/funbox/src/socket/socket.service.ts
+++ b/BackEnd/funbox/src/socket/socket.service.ts
@@ -49,8 +49,11 @@ export class SocketService {
 
   gameApply(client: Socket, opponentId: number) {
     const opponentClient = this.userIdToClient.get(opponentId);
-    if (!opponentClient) {
-      const data = JSON.stringify({ answer: GameApplyAnswer.OFFLINE });
+    if (!opponentClient || opponentClient.data.roomId) {
+      const answer = !opponentClient
+        ? GameApplyAnswer.OFFLINE
+        : GameApplyAnswer.PLAYING;
+      const data = JSON.stringify({ answer });
       this.logger.log(`gameApplyAnswer to ${client.data.userId}: ${data}`);
       client.emit('gameApplyAnswer', data);
     } else {

--- a/BackEnd/funbox/src/socket/socket.service.ts
+++ b/BackEnd/funbox/src/socket/socket.service.ts
@@ -73,7 +73,7 @@ export class SocketService {
     if (answer === GameApplyAnswer.REJECT) {
       this.gameService.deleteGameRoom(roomId);
     } else {
-      this.gameService.startGame(roomId, 2);
+      this.gameService.startGame(roomId, 4);
     }
   }
 


### PR DESCRIPTION
# 제목
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경변수, 빌드관련 코드 업데이트

### 반영 브랜치
feature-game -> dev_back

### 변경사항
- 게임 플레이 중이 아닐 때, 게임 관련 동작 거부:
게임에 들어와 있지만 플레이 중이 아닌 경우, 허가되지 않은 이벤트는 `ForbiddenException`을 던지도록 했습니다.
- 게임 중 게임 신청을 받을 수 없도록 변경:
게임 신청을 이미 받았거나 플레이중인 경우, PLAYING answer를 보내도록 했습니다.

### 테스트 결과
- 게임 중이 아닌데, 게임 이벤트를 수행할 경우 예외 처리
<img width="952" alt="스크린샷 2023-12-11 14 26 25" src="https://github.com/boostcampwm2023/and05-funbox/assets/42964952/3e9fe2d6-7b9b-491e-be02-164233ce9a18">

- 게임 신청을 받은 뒤, 수락/거절 하지 않고, 게임 이벤트를 수행할 경우 예외 처리
<img width="952" alt="스크린샷 2023-12-11 14 24 59" src="https://github.com/boostcampwm2023/and05-funbox/assets/42964952/24d20d60-786c-447b-bbb6-b00e7308359e">

- 이미 신청을 받았거나, 게임을 플레이 중인 유저에게 게임 신청을 보낸 경우 예외 처리
<img width="952" alt="스크린샷 2023-12-11 14 28 34" src="https://github.com/boostcampwm2023/and05-funbox/assets/42964952/1e7f6752-68f5-42c2-851c-3fbc319a2f12">
